### PR TITLE
Finetune control plane and network

### DIFF
--- a/charts/internal/vsphere-infra/templates/main.tf
+++ b/charts/internal/vsphere-infra/templates/main.tf
@@ -58,10 +58,18 @@ data "nsxt_ip_pool" "snat_pool" {
 # create logical router & switch
 #################################
 
+resource "random_id" "switchSuffix" {
+  byte_length = 3
+}
+
+locals {
+    network_name = "${var.nsx_full_cluster_name}-${random_id.switchSuffix.hex}"
+}
+
 resource "nsxt_logical_switch" "switch" {
   admin_state = "UP"
   description = "logical switch for gardener cluster"
-  display_name = "${var.nsx_full_cluster_name}"
+  display_name = "${local.network_name}"
   transport_zone_id = "${data.nsxt_transport_zone.cluster.id}"
   replication_mode = "MTEP"
 
@@ -281,7 +289,7 @@ resource "nsxt_dhcp_server_ip_pool" "dhcp_pool" {
 //=====================================================================
 
 output "network_name" {
-  value = "${var.nsx_full_cluster_name}"
+  value = "${local.network_name}"
 }
 
 output "logical_router_id" {

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -60,6 +60,7 @@ loadBalancerClasses:
   - name: mypubliclbclass
   - name: myprivatelbclass
     ipPoolName: pool42 # optional overwrite
+loadBalancerSize: SMALL
 cloudControllerManager:
   featureGates:
     CustomResourceValidation: true
@@ -70,6 +71,10 @@ The specified names must be defined in the constraints section of the cloud prof
 If the list contains a load balancer named "default", it is used as the default load balancer.
 Otherwise the first one is also the default.
 If no classes are specified the default load balancer class is used as defined in the cloud profile constraints section.
+
+The `loadBalancerSize` is optional and overwrites the default value specified in the cloud profile config.
+It must be one of the values `SMALL`, `MEDIUM`, or `LARGE`. `SMALL` can manage 10 service ports,
+`MEDIUM` 100, and `LARGE` 1000. 
 
 The `cloudControllerManager.featureGates` contains an optional map of explicitly enabled or disabled feature gates.
 For production usage it's not recommend to use this field at all as you can enable alpha features or disable beta/stable features, potentially impacting the cluster stability.

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -207,6 +207,18 @@ CloudControllerManagerConfig
 <p>LoadBalancerClasses lists the load balancer classes to be used.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>loadBalancerSize</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LoadBalancerSize can override the default of the NSX-T load balancer size (&ldquo;SMALL&rdquo;, &ldquo;MEDIUM&rdquo;, or &ldquo;LARGE&rdquo;) defined in the cloud profile.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="vsphere.provider.extensions.gardener.cloud/v1alpha1.InfrastructureConfig">InfrastructureConfig

--- a/pkg/apis/vsphere/types_controlplane.go
+++ b/pkg/apis/vsphere/types_controlplane.go
@@ -28,6 +28,8 @@ type ControlPlaneConfig struct {
 	CloudControllerManager *CloudControllerManagerConfig
 	// LoadBalancerClasses lists the load balancer classes to be used.
 	LoadBalancerClasses []CPLoadBalancerClass
+	// LoadBalancerSize can override the default of the NSX-T load balancer size ("SMALL", "MEDIUM", or "LARGE") defined in the cloud profile.
+	LoadBalancerSize *string
 }
 
 // CloudControllerManagerConfig contains configuration settings for the cloud-controller-manager.

--- a/pkg/apis/vsphere/v1alpha1/types_controlplane.go
+++ b/pkg/apis/vsphere/v1alpha1/types_controlplane.go
@@ -31,6 +31,9 @@ type ControlPlaneConfig struct {
 	// LoadBalancerClasses lists the load balancer classes to be used.
 	// +optional
 	LoadBalancerClasses []CPLoadBalancerClass `json:"loadBalancerClasses,omitempty"`
+	// LoadBalancerSize can override the default of the NSX-T load balancer size ("SMALL", "MEDIUM", or "LARGE") defined in the cloud profile.
+	// +optional
+	LoadBalancerSize *string `json:"loadBalancerSize,omitempty"`
 }
 
 // CloudControllerManagerConfig contains configuration settings for the cloud-controller-manager.

--- a/pkg/apis/vsphere/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/vsphere/v1alpha1/zz_generated.conversion.go
@@ -325,6 +325,7 @@ func Convert_vsphere_Constraints_To_v1alpha1_Constraints(in *vsphere.Constraints
 func autoConvert_v1alpha1_ControlPlaneConfig_To_vsphere_ControlPlaneConfig(in *ControlPlaneConfig, out *vsphere.ControlPlaneConfig, s conversion.Scope) error {
 	out.CloudControllerManager = (*vsphere.CloudControllerManagerConfig)(unsafe.Pointer(in.CloudControllerManager))
 	out.LoadBalancerClasses = *(*[]vsphere.CPLoadBalancerClass)(unsafe.Pointer(&in.LoadBalancerClasses))
+	out.LoadBalancerSize = (*string)(unsafe.Pointer(in.LoadBalancerSize))
 	return nil
 }
 
@@ -336,6 +337,7 @@ func Convert_v1alpha1_ControlPlaneConfig_To_vsphere_ControlPlaneConfig(in *Contr
 func autoConvert_vsphere_ControlPlaneConfig_To_v1alpha1_ControlPlaneConfig(in *vsphere.ControlPlaneConfig, out *ControlPlaneConfig, s conversion.Scope) error {
 	out.CloudControllerManager = (*CloudControllerManagerConfig)(unsafe.Pointer(in.CloudControllerManager))
 	out.LoadBalancerClasses = *(*[]CPLoadBalancerClass)(unsafe.Pointer(&in.LoadBalancerClasses))
+	out.LoadBalancerSize = (*string)(unsafe.Pointer(in.LoadBalancerSize))
 	return nil
 }
 

--- a/pkg/apis/vsphere/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/vsphere/v1alpha1/zz_generated.deepcopy.go
@@ -151,6 +151,11 @@ func (in *ControlPlaneConfig) DeepCopyInto(out *ControlPlaneConfig) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.LoadBalancerSize != nil {
+		in, out := &in.LoadBalancerSize, &out.LoadBalancerSize
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/vsphere/validation/cloudprofile.go
+++ b/pkg/apis/vsphere/validation/cloudprofile.go
@@ -16,8 +16,8 @@ package validation
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/util/sets"
-	"strings"
 
 	apisvsphere "github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/vsphere"
 
@@ -35,8 +35,8 @@ func ValidateCloudProfileConfig(cloudProfile *apisvsphere.CloudProfileConfig) fi
 		allErrs = append(allErrs, field.Required(loadBalancerSizePath, "must provide the load balancer size"))
 	} else {
 		if !validLoadBalancerSizeValues.Has(cloudProfile.Constraints.LoadBalancerConfig.Size) {
-			allErrs = append(allErrs, field.Required(loadBalancerSizePath,
-				fmt.Sprintf("must provide a valid load balancer size value (%s)", strings.Join(validLoadBalancerSizeValues.List(), ","))))
+			allErrs = append(allErrs, field.NotSupported(loadBalancerSizePath,
+				cloudProfile.Constraints.LoadBalancerConfig.Size, validLoadBalancerSizeValues.List()))
 		}
 	}
 

--- a/pkg/apis/vsphere/validation/cloudprofile.go
+++ b/pkg/apis/vsphere/validation/cloudprofile.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-var validValues = sets.NewString("SMALL", "MEDIUM", "LARGE")
+var validLoadBalancerSizeValues = sets.NewString("SMALL", "MEDIUM", "LARGE")
 
 // ValidateCloudProfileConfig validates a CloudProfileConfig object.
 func ValidateCloudProfileConfig(cloudProfile *apisvsphere.CloudProfileConfig) field.ErrorList {
@@ -34,9 +34,9 @@ func ValidateCloudProfileConfig(cloudProfile *apisvsphere.CloudProfileConfig) fi
 	if cloudProfile.Constraints.LoadBalancerConfig.Size == "" {
 		allErrs = append(allErrs, field.Required(loadBalancerSizePath, "must provide the load balancer size"))
 	} else {
-		if !validValues.Has(cloudProfile.Constraints.LoadBalancerConfig.Size) {
+		if !validLoadBalancerSizeValues.Has(cloudProfile.Constraints.LoadBalancerConfig.Size) {
 			allErrs = append(allErrs, field.Required(loadBalancerSizePath,
-				fmt.Sprintf("must provide a valid load balancer size value (%s)", strings.Join(validValues.List(), ","))))
+				fmt.Sprintf("must provide a valid load balancer size value (%s)", strings.Join(validLoadBalancerSizeValues.List(), ","))))
 		}
 	}
 

--- a/pkg/apis/vsphere/validation/cloudprofile_test.go
+++ b/pkg/apis/vsphere/validation/cloudprofile_test.go
@@ -159,7 +159,7 @@ var _ = Describe("ValidateCloudProfileConfig", func() {
 				errorList := ValidateCloudProfileConfig(cloudProfileConfig)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
+					"Type":  Equal(field.ErrorTypeNotSupported),
 					"Field": Equal("constraints.loadBalancerConfig.size"),
 				}))))
 			})

--- a/pkg/apis/vsphere/validation/controlplane.go
+++ b/pkg/apis/vsphere/validation/controlplane.go
@@ -15,10 +15,9 @@
 package validation
 
 import (
-	"strings"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
 	apisvsphere "github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/vsphere"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -41,8 +40,8 @@ func ValidateControlPlaneConfig(controlPlaneConfig *apisvsphere.ControlPlaneConf
 
 	if controlPlaneConfig.LoadBalancerSize != nil {
 		if !validLoadBalancerSizeValues.Has(*controlPlaneConfig.LoadBalancerSize) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("loadBalancerSize"),
-				"must provide a valid load balancer size value", strings.Join(validLoadBalancerSizeValues.List(), ",")))
+			allErrs = append(allErrs, field.NotSupported(field.NewPath("loadBalancerSize"),
+				*controlPlaneConfig.LoadBalancerSize, validLoadBalancerSizeValues.List()))
 		}
 	}
 

--- a/pkg/apis/vsphere/validation/controlplane.go
+++ b/pkg/apis/vsphere/validation/controlplane.go
@@ -15,9 +15,11 @@
 package validation
 
 import (
-	apisvsphere "github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/vsphere"
+	"strings"
 
+	apisvsphere "github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/vsphere"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -34,6 +36,13 @@ func ValidateControlPlaneConfig(controlPlaneConfig *apisvsphere.ControlPlaneConf
 			allErrs = append(allErrs, field.Required(field.NewPath("loadBalancerClasses", "name"), "name of load balancer class must be set"))
 		} else if _, ok := knownClassNames[lbclass.Name]; !ok {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("loadBalancerClasses", "name"), lbclass.Name, "must be defined in in cloud profile constraints"))
+		}
+	}
+
+	if controlPlaneConfig.LoadBalancerSize != nil {
+		if !validLoadBalancerSizeValues.Has(*controlPlaneConfig.LoadBalancerSize) {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("loadBalancerSize"),
+				"must provide a valid load balancer size value", strings.Join(validLoadBalancerSizeValues.List(), ",")))
 		}
 	}
 

--- a/pkg/apis/vsphere/validation/controlplane_test.go
+++ b/pkg/apis/vsphere/validation/controlplane_test.go
@@ -92,6 +92,21 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 				"Field": Equal("loadBalancerClasses.name"),
 			}))))
 		})
+
+		It("should check valid value for load balancer size", func() {
+			s := "LARGE"
+			controlPlane.LoadBalancerSize = &s
+			errorList := ValidateControlPlaneConfig(controlPlane, region, regions, constraints)
+			Expect(errorList).To(ConsistOf())
+
+			s2 := "foo"
+			controlPlane.LoadBalancerSize = &s2
+			errorList = ValidateControlPlaneConfig(controlPlane, region, regions, constraints)
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("loadBalancerSize"),
+			}))))
+		})
 	})
 
 	Describe("#ValidateControlPlaneConfigUpdate", func() {

--- a/pkg/apis/vsphere/validation/controlplane_test.go
+++ b/pkg/apis/vsphere/validation/controlplane_test.go
@@ -103,7 +103,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			controlPlane.LoadBalancerSize = &s2
 			errorList = ValidateControlPlaneConfig(controlPlane, region, regions, constraints)
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
+				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("loadBalancerSize"),
 			}))))
 		})

--- a/pkg/apis/vsphere/zz_generated.deepcopy.go
+++ b/pkg/apis/vsphere/zz_generated.deepcopy.go
@@ -151,6 +151,11 @@ func (in *ControlPlaneConfig) DeepCopyInto(out *ControlPlaneConfig) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.LoadBalancerSize != nil {
+		in, out := &in.LoadBalancerSize, &out.LoadBalancerSize
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -398,9 +398,13 @@ outer:
 		return nil, fmt.Errorf("load balancer default class %q must specify both ipPoolName and size in cloud profile", defaultClass.Name)
 	}
 
+	lbSize := cloudProfileConfig.Constraints.LoadBalancerConfig.Size
+	if cpConfig.LoadBalancerSize != nil && *cpConfig.LoadBalancerSize != "" {
+		lbSize = *cpConfig.LoadBalancerSize
+	}
 	loadBalancers := map[string]interface{}{
 		"ipPoolName": defaultClass.IPPoolName,
-		"size":       cloudProfileConfig.Constraints.LoadBalancerConfig.Size,
+		"size":       lbSize,
 		"classes":    loadBalancersClasses,
 	}
 	if infraStatus.LogicalRouterId != "" {

--- a/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/pkg/webhook/controlplaneexposure/ensurer.go
@@ -18,12 +18,13 @@ import (
 	"context"
 
 	"github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/config"
+	"github.com/gardener/gardener-extensions/pkg/controller"
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
-
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -54,6 +55,15 @@ func (e *ensurer) InjectClient(client client.Client) error {
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx genericmutator.EnsurerContext, dep *appsv1.Deployment) error {
+	cluster, err := controller.GetCluster(ctx, e.client, dep.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if controller.IsHibernated(cluster) {
+		return nil
+	}
+
 	// Get load balancer address of the kube-apiserver service
 	address, err := kutil.GetLoadBalancerIngress(ctx, e.client, dep.Namespace, v1alpha1constants.DeploymentNameKubeAPIServer)
 	if err != nil {

--- a/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -16,7 +16,7 @@ package controlplaneexposure
 
 import (
 	"context"
-	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
+	"encoding/json"
 	"testing"
 
 	"github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/config"
@@ -24,8 +24,11 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/util"
 	extensionswebhook "github.com/gardener/gardener-extensions/pkg/webhook"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
-
+	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -69,6 +72,13 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		}
+		cluster = &extensionsv1alpha1.Cluster{
+			Spec: extensionsv1alpha1.ClusterSpec{
+				Shoot: runtime.RawExtension{
+					Raw: encode(&gardencorev1beta1.Shoot{}),
+				},
+			},
+		}
 	)
 
 	BeforeEach(func() {
@@ -99,12 +109,13 @@ var _ = Describe("Ensurer", func() {
 			)
 
 			// Create mock client
-			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
+			c := mockclient.NewMockClient(ctrl)
+			c.EXPECT().Get(context.TODO(), client.ObjectKey{Name: namespace}, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(cluster))
+			c.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
 
 			// Create ensurer
 			ensurer := NewEnsurer(etcdStorage, logger)
-			err := ensurer.(inject.Client).InjectClient(client)
+			err := ensurer.(inject.Client).InjectClient(c)
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
@@ -133,12 +144,13 @@ var _ = Describe("Ensurer", func() {
 			)
 
 			// Create mock client
-			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
+			c := mockclient.NewMockClient(ctrl)
+			c.EXPECT().Get(context.TODO(), client.ObjectKey{Name: namespace}, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(cluster))
+			c.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{}).DoAndReturn(clientGet(svc))
 
 			// Create ensurer
 			ensurer := NewEnsurer(etcdStorage, logger)
-			err := ensurer.(inject.Client).InjectClient(client)
+			err := ensurer.(inject.Client).InjectClient(c)
 			Expect(err).To(Not(HaveOccurred()))
 
 			// Call EnsureKubeAPIServerDeployment method and check the result
@@ -269,7 +281,14 @@ func clientGet(result runtime.Object) interface{} {
 		switch obj.(type) {
 		case *corev1.Service:
 			*obj.(*corev1.Service) = *result.(*corev1.Service)
+		case *extensionsv1alpha1.Cluster:
+			*obj.(*extensionsv1alpha1.Cluster) = *result.(*extensionsv1alpha1.Cluster)
 		}
 		return nil
 	}
+}
+
+func encode(obj runtime.Object) []byte {
+	data, _ := json.Marshal(obj)
+	return data
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Several minor improvements for control plane and network naming:
- fix kube-apiserver svc after hibernation
- allow to override load balancer size in controlplaneconfig
- add random suffix to logical switch name to avoid name clash if cleanup fails in vsphere

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
fix kube-apiserver svc after hibernation
```

```improvement operator
allow to override load balancer size in controlplaneconfig
```

```improvement operator
add random suffix to logical switch name to avoid name clash if cleanup fails in vsphere
```
