### PR TITLE
[ci:component:github.com/gardener/etcd-backup-restore:0.7.3->0.8.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.7.3"
+  tag: "0.8.0"
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher


### PR DESCRIPTION
*Release Notes*:
``` improvement user github.com/gardener/etcd-backup-restore #200 @swapnilgm
Fix the error handling in revision consistency check leading to restoration on valid etcd data directory.
```

``` improvement operator github.com/gardener/etcd-backup-restore #197 @swapnilgm
Fix the object listing for OSS snapstore
```

``` noteworthy developer github.com/gardener/etcd-backup-restore #196 @shreyas-s-rao
Added TLS support for backup-restore server. TLS can be enabled by passing the paths to both TLS cert and key PEM-format files via `--server-cert` and `--server-key` flags.
```

``` action user github.com/gardener/etcd-backup-restore #194 @swapnilgm
Defragmentation schedule can be configured now in cron standards using flag `defragmentation-schedule`. :warning: Removed the flag `defragmentation-period-hours`.
```

``` action user github.com/gardener/etcd-backup-restore #194 @swapnilgm
:warning: Removed the flag `delta-snapshot-period-seconds`. Instead use replacement flag `delta-snapshot-period` with input value format supported by golang `time.Duration`.
```

``` action user github.com/gardener/etcd-backup-restore #194 @swapnilgm
:warning: Removed the flag `garbage-collection-period-seconds`. Instead use replacement flag `garbage-collection-period` with input value format supported by golang `time.Duration`.
```

``` improvement developer github.com/gardener/etcd-backup-restore #193 @shreyas-s-rao
Expose new metric `etcdbr_snapshot_required`.
```

``` improvement user github.com/gardener/etcd-backup-restore #192 @swapnilgm
Expose http API to trigger out-of-schedule delta snapshot.
```

``` improvement operator github.com/gardener/etcd-backup-restore #190 @swapnilgm
[Fix] Cleanup in-memory events before stopping snapshotter.
```

``` improvement operator github.com/gardener/etcd-backup-restore #188 @shreyas-s-rao
Added documentation for restoration.
```

``` improvement operator github.com/gardener/etcd-backup-restore #173 @ashwani2k
Added negative tests for restoration of snapshots.
```

``` improvement operator github.com/gardener/etcd-backup-restore #171 @amshuman-kr
Performance regression tests can be executed using the `make perf-regression-test` target against the Kubernetes cluster pointed to by the environment variable PERF_TEST_KUBECONFIG.
```