### PR TITLE
Filter api expose objects

### DIFF
--- a/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/pkg/webhook/controlplaneexposure/ensurer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener-extensions/pkg/webhook/controlplane/genericmutator"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"github.com/go-logr/logr"
@@ -55,6 +56,10 @@ func (e *ensurer) InjectClient(client client.Client) error {
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx genericmutator.EnsurerContext, dep *appsv1.Deployment) error {
+	if v1beta1helper.IsAPIServerExposureManaged(dep) {
+		return nil
+	}
+
 	cluster, err := controller.GetCluster(ctx, e.client, dep.Namespace)
 	if err != nil {
 		return err

--- a/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -90,6 +90,38 @@ var _ = Describe("Ensurer", func() {
 	})
 
 	Describe("#EnsureKubeAPIServerDeployment", func() {
+		It("should not modify kube-apiserver deployment if SNI is enabled", func() {
+			var (
+				dep = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      v1alpha1constants.DeploymentNameKubeAPIServer,
+						Namespace: namespace,
+						Labels:    map[string]string{"core.gardener.cloud/apiserver-exposure": "gardener-managed"},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "kube-apiserver",
+									},
+								},
+							},
+						},
+					},
+				}
+				depCopy = dep.DeepCopy()
+			)
+
+			// Create ensurer
+			ensurer := NewEnsurer(etcdStorage, logger)
+
+			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep)
+			Expect(err).To(Not(HaveOccurred()))
+
+			Expect(dep).To(Equal(depCopy))
+		})
+
 		It("should add missing elements to kube-apiserver deployment", func() {
 			var (
 				dep = &appsv1.Deployment{

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -223,6 +223,13 @@ const (
 	// LabelScheduler is a constant for a label for the kube-scheduler.
 	LabelScheduler = "scheduler"
 
+	// LabelAPIServerExposure is a constant for label key which gardener can add to various objects related
+	// to kube-apiserver exposure.
+	LabelAPIServerExposure = "core.gardener.cloud/apiserver-exposure"
+	// LabelAPIServerExposureGardenerManaged is a constant for label value which gardener sets on the label key
+	// "core.gardener.cloud/apiserver-exposure" to indicate that it's responsible for apiserver exposure (via SNI).
+	LabelAPIServerExposureGardenerManaged = "gardener-managed"
+
 	// GardenNamespace is the namespace in which the configuration and secrets for
 	// the Gardener controller manager will be stored (e.g., secrets for the Seed clusters).
 	// It is also used by the gardener-apiserver.

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -223,6 +223,13 @@ const (
 	// LabelScheduler is a constant for a label for the kube-scheduler.
 	LabelScheduler = "scheduler"
 
+	// LabelAPIServerExposure is a constant for label key which gardener can add to various objects related
+	// to kube-apiserver exposure.
+	LabelAPIServerExposure = "core.gardener.cloud/apiserver-exposure"
+	// LabelAPIServerExposureGardenerManaged is a constant for label value which gardener sets on the label key
+	// "core.gardener.cloud/apiserver-exposure" to indicate that it's responsible for apiserver exposure (via SNI).
+	LabelAPIServerExposureGardenerManaged = "gardener-managed"
+
 	// GardenNamespace is the namespace in which the configuration and secrets for
 	// the Gardener controller manager will be stored (e.g., secrets for the Seed clusters).
 	// It is also used by the gardener-apiserver.

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/helper.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/helper.go
@@ -740,3 +740,19 @@ func WrapWithLastError(err error, lastError *gardencorev1beta1.LastError) error 
 	}
 	return errors.Wrapf(err, "last error: %s", lastError.Description)
 }
+
+// IsAPIServerExposureManaged returns true, if the Object is managed by Gardener for API server exposure.
+// This indicates to extensions that they should not mutate the object.
+// Gardener marks the kube-apiserver Service and Deployment as managed by it when it uses SNI to expose them.
+func IsAPIServerExposureManaged(obj metav1.Object) bool {
+	if obj == nil {
+		return false
+	}
+
+	if v, found := obj.GetLabels()[v1beta1constants.LabelAPIServerExposure]; found &&
+		v == v1beta1constants.LabelAPIServerExposureGardenerManaged {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not mutate kube-apiserver exposure resources when gardener manages those. See https://github.com/gardener/gardener/pull/1929

**Which issue(s) this PR fixes**:
Fixes # n/a

**Special notes for your reviewer**:

This is WIP as https://github.com/gardener/gardener/commit/40864019e030923c80657ac5d46a34130bcf337d is still not available in any tags and vendor folder manually updated

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Do not mutate `kube-apiserver` exposure resources which Gardener marks as managed by it with `core.gardener.cloud/apiserver-exposure: gardener-managed` label.
```
