### PR TITLE
remove obsolete terraformer references

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -1,8 +1,4 @@
 images:
-- name: terraformer
-  sourceRepository: github.com/gardener/terraformer
-  repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.19.0"
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher

--- a/pkg/imagevector/imagevector.go
+++ b/pkg/imagevector/imagevector.go
@@ -21,8 +21,6 @@ package imagevector
 import (
 	"strings"
 
-	"github.com/gardener/gardener-extension-provider-vsphere/pkg/vsphere"
-
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/gobuffalo/packr/v2"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -46,11 +44,4 @@ func init() {
 // ImageVector is the image vector that contains all the needed images.
 func ImageVector() imagevector.ImageVector {
 	return imageVector
-}
-
-// TerraformerImage retrieves the Terraformer image.
-func TerraformerImage() string {
-	image, err := imageVector.FindImage(vsphere.TerraformerImageName)
-	runtime.Must(err)
-	return image.String()
 }

--- a/pkg/vsphere/types.go
+++ b/pkg/vsphere/types.go
@@ -22,8 +22,6 @@ const (
 	// Name is the name of the vSphere provider controller.
 	Name = "provider-vsphere"
 
-	// TerraformerImageName is the name of the Terraformer image.
-	TerraformerImageName = "terraformer"
 	// MachineControllerManagerImageName is the name of the MachineControllerManager image.
 	MachineControllerManagerImageName = "machine-controller-manager"
 	// MCMProviderVsphereImageName is the namne of the vSphere provider plugin image.


### PR DESCRIPTION
**What this PR does / why we need it**:
Some references to terraformer have been missed to be removed after Terraformer has been replaced with direct NSX-T API usage.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
