### PR TITLE
Allow to delete infrastructure if creation was tried with invalid credentials

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -570,6 +570,16 @@ VsphereConfig
 </tr>
 <tr>
 <td>
+<code>creationStarted</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
 <code>nsxtInfraState</code></br>
 <em>
 <a href="#vsphere.provider.extensions.gardener.cloud/v1alpha1.NSXTInfraState">

--- a/pkg/apis/vsphere/types_infrastructure.go
+++ b/pkg/apis/vsphere/types_infrastructure.go
@@ -90,5 +90,6 @@ type InfrastructureStatus struct {
 
 	VsphereConfig VsphereConfig
 
-	NSXTInfraState *NSXTInfraState
+	CreationStarted *bool
+	NSXTInfraState  *NSXTInfraState
 }

--- a/pkg/apis/vsphere/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/vsphere/v1alpha1/types_infrastructure.go
@@ -91,5 +91,6 @@ type InfrastructureStatus struct {
 
 	VsphereConfig VsphereConfig `json:"vsphereConfig"`
 
-	NSXTInfraState *NSXTInfraState `json:"nsxtInfraState,omitempty"`
+	CreationStarted *bool           `json:"creationStarted,omitempty"`
+	NSXTInfraState  *NSXTInfraState `json:"nsxtInfraState,omitempty"`
 }

--- a/pkg/apis/vsphere/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/vsphere/v1alpha1/zz_generated.conversion.go
@@ -452,6 +452,7 @@ func autoConvert_v1alpha1_InfrastructureStatus_To_vsphere_InfrastructureStatus(i
 	if err := Convert_v1alpha1_VsphereConfig_To_vsphere_VsphereConfig(&in.VsphereConfig, &out.VsphereConfig, s); err != nil {
 		return err
 	}
+	out.CreationStarted = (*bool)(unsafe.Pointer(in.CreationStarted))
 	out.NSXTInfraState = (*vsphere.NSXTInfraState)(unsafe.Pointer(in.NSXTInfraState))
 	return nil
 }
@@ -465,6 +466,7 @@ func autoConvert_vsphere_InfrastructureStatus_To_v1alpha1_InfrastructureStatus(i
 	if err := Convert_vsphere_VsphereConfig_To_v1alpha1_VsphereConfig(&in.VsphereConfig, &out.VsphereConfig, s); err != nil {
 		return err
 	}
+	out.CreationStarted = (*bool)(unsafe.Pointer(in.CreationStarted))
 	out.NSXTInfraState = (*NSXTInfraState)(unsafe.Pointer(in.NSXTInfraState))
 	return nil
 }

--- a/pkg/apis/vsphere/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/vsphere/v1alpha1/zz_generated.deepcopy.go
@@ -274,6 +274,11 @@ func (in *InfrastructureStatus) DeepCopyInto(out *InfrastructureStatus) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.VsphereConfig.DeepCopyInto(&out.VsphereConfig)
+	if in.CreationStarted != nil {
+		in, out := &in.CreationStarted, &out.CreationStarted
+		*out = new(bool)
+		**out = **in
+	}
 	if in.NSXTInfraState != nil {
 		in, out := &in.NSXTInfraState, &out.NSXTInfraState
 		*out = new(NSXTInfraState)

--- a/pkg/apis/vsphere/zz_generated.deepcopy.go
+++ b/pkg/apis/vsphere/zz_generated.deepcopy.go
@@ -274,6 +274,11 @@ func (in *InfrastructureStatus) DeepCopyInto(out *InfrastructureStatus) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.VsphereConfig.DeepCopyInto(&out.VsphereConfig)
+	if in.CreationStarted != nil {
+		in, out := &in.CreationStarted, &out.CreationStarted
+		*out = new(bool)
+		**out = **in
+	}
 	if in.NSXTInfraState != nil {
 		in, out := &in.NSXTInfraState, &out.NSXTInfraState
 		*out = new(NSXTInfraState)

--- a/pkg/vsphere/infrastructure/interface.go
+++ b/pkg/vsphere/infrastructure/interface.go
@@ -49,7 +49,15 @@ type NSXTConfig struct {
 	CAFile             string `json:"ca-file,omitempty"`
 }
 
+// NSXTInfrastructureEnsurer ensures that infrastructure is completed created or deleted
 type NSXTInfrastructureEnsurer interface {
+	// CheckConnection checks if the NSX-T REST API is reachable with the given endpoint and credentials.
+	CheckConnection() error
+	// EnsureInfrastructure ensures that the infrastructure is complete
+	// It checks all infrastructure objects and creates missing one or updates them if important attributes have been changed.
+	// It can even recover objects not recorded in the state.
 	EnsureInfrastructure(spec NSXTInfraSpec, state *api.NSXTInfraState) error
+	// EnsureInfrastructureDeleted ensures that all infrastructure objects are deleted
+	// It even trys to recover objects not recorded in the state before deleting them.
 	EnsureInfrastructureDeleted(spec *NSXTInfraSpec, state *api.NSXTInfraState) error
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If the NSX-T credentials were invalid at cluster creation time, there was no easy way to delete the cluster although nothing has been done on the NSX-T infrastructure.

**Which issue(s) this PR fixes**:
Fixes #3 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Allow to delete infrastructure if cluster creation was tried with invalid credentials
```
