### PR TITLE
Fix number of arguments for logger calls

### DIFF
--- a/pkg/validator/shoot_handler.go
+++ b/pkg/validator/shoot_handler.go
@@ -42,7 +42,7 @@ type Shoot struct {
 func (v *Shoot) Handle(ctx context.Context, req admission.Request) admission.Response {
 	shoot := &core.Shoot{}
 	if err := util.Decode(v.decoder, req.Object.Raw, shoot); err != nil {
-		v.Logger.Error(err, "failed to decode shoot", string(req.Object.Raw))
+		v.Logger.Error(err, "failed to decode shoot", "shoot", string(req.Object.Raw))
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
@@ -59,7 +59,7 @@ func (v *Shoot) Handle(ctx context.Context, req admission.Request) admission.Res
 	case admissionv1beta1.Update:
 		oldShoot := &core.Shoot{}
 		if err := util.Decode(v.decoder, req.OldObject.Raw, oldShoot); err != nil {
-			v.Logger.Error(err, "failed to decode old shoot", string(req.OldObject.Raw))
+			v.Logger.Error(err, "failed to decode old shoot", "old shoot", string(req.OldObject.Raw))
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 
@@ -68,7 +68,7 @@ func (v *Shoot) Handle(ctx context.Context, req admission.Request) admission.Res
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 	default:
-		v.Logger.Info("Webhook not responsible", "Operation", req.Operation)
+		v.Logger.Info("Webhook not responsible", "operation", req.Operation)
 	}
 
 	return admission.Allowed("validations succeeded")


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix number of arguments for logger calls. Ref gardener/gardener-extensions#636.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
