### PR TITLE
Align chart and http endpoint for validation

### DIFF
--- a/charts/gardener-extension-validator-vsphere/charts/application/templates/validatingwebhook-validator.yaml
+++ b/charts/gardener-extension-validator-vsphere/charts/application/templates/validatingwebhook-validator.yaml
@@ -20,11 +20,11 @@ webhooks:
   namespaceSelector: {}
   clientConfig:
     {{- if .Values.global.virtualGarden.enabled }}
-    url: {{ printf "https://gardener-extension-validator-vsphere.%s/webhooks/validate-shoot" .Release.Namespace }}
+    url: {{ printf "https://%s.%s/webhooks/validate" (include "name" .) (.Release.Namespace) }}
     {{- else }}
     service:
       namespace: {{ .Release.Namespace }}
       name: {{ include "name" . }}
-      path: /webhooks/validate-shoot
+      path: /webhooks/validate
     {{- end }}
     caBundle: {{ required ".Values.webhookConfig.caBundle is required" (b64enc .Values.global.webhookConfig.caBundle) }}

--- a/cmd/gardener-extension-validator-vsphere/app/app.go
+++ b/cmd/gardener-extension-validator-vsphere/app/app.go
@@ -76,7 +76,7 @@ func NewValidatorCommand(ctx context.Context) *cobra.Command {
 			hookServer := mgr.GetWebhookServer()
 
 			log.Info("Registering webhooks")
-			hookServer.Register("/webhooks/validate-shoot-vsphere", &webhook.Admission{Handler: &validator.Shoot{Logger: log.WithName("shoot-validator")}})
+			hookServer.Register("/webhooks/validate", &webhook.Admission{Handler: &validator.Shoot{Logger: log.WithName("shoot-validator")}})
 
 			if err := mgr.Start(ctx.Done()); err != nil {
 				controllercmd.LogErrAndExit(err, "Error running manager")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR matches the http endpoint `webhooks/validate` for the vsphere validation webhook with the provided chart.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
None
```
