### PR TITLE
make infrastructureconfig optional in the shoot validator

### DIFF
--- a/pkg/validator/shoot_validator.go
+++ b/pkg/validator/shoot_validator.go
@@ -104,16 +104,17 @@ func (v *Shoot) validateShoot(context *validationContext) field.ErrorList {
 }
 
 func newValidationContext(ctx context.Context, c client.Client, shoot *core.Shoot) (*validationContext, error) {
-	if shoot.Spec.Provider.InfrastructureConfig == nil {
-		return nil, field.Required(infraConfigPath, "infrastructureConfig must be set for OpenStack shoots")
-	}
-	infraConfig, err := helper.DecodeInfrastructureConfig(shoot.Spec.Provider.InfrastructureConfig, infraConfigPath)
-	if err != nil {
-		return nil, err
+	infraConfig := &vsphere.InfrastructureConfig{}
+	if shoot.Spec.Provider.InfrastructureConfig != nil {
+		var err error
+		infraConfig, err = helper.DecodeInfrastructureConfig(shoot.Spec.Provider.InfrastructureConfig, infraConfigPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if shoot.Spec.Provider.ControlPlaneConfig == nil {
-		return nil, field.Required(cpConfigPath, "controlPlaneConfig must be set for OpenStack shoots")
+		return nil, field.Required(cpConfigPath, "controlPlaneConfig must be set for vSphere shoots")
 	}
 	cpConfig, err := helper.DecodeControlPlaneConfig(shoot.Spec.Provider.ControlPlaneConfig, cpConfigPath)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
If you create a vSphere shoot from the Gardener dashboard, the infrastructureconfig is currently not set in the shoot yaml, as it is not used. Therefore the shoot validator does not require the infrastructureconfig anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
