### PR TITLE
Keep additional tags on NSX-T objects

### DIFF
--- a/pkg/vsphere/infrastructure/task/helpers.go
+++ b/pkg/vsphere/infrastructure/task/helpers.go
@@ -131,3 +131,19 @@ outer:
 	}
 	return true
 }
+
+// mergeTags merges two tag arrays using scope as key
+func mergeTags(a []model.Tag, b []model.Tag) []model.Tag {
+	result := make([]model.Tag, len(a))
+	copy(result, a)
+outer:
+	for _, tag := range b {
+		for _, t := range a {
+			if *t.Scope == *tag.Scope {
+				continue outer
+			}
+		}
+		result = append(result, tag)
+	}
+	return result
+}

--- a/pkg/vsphere/infrastructure/task/helpers_test.go
+++ b/pkg/vsphere/infrastructure/task/helpers_test.go
@@ -80,6 +80,29 @@ var _ = Describe("Helpers", func() {
 			Expect(containsTags(tags1, itemTags)).To(Equal(false))
 		})
 	})
+	Describe("#mergeTags", func() {
+		It("should merge tags", func() {
+			tags1 := []model.Tag{
+				{Scope: sp("owner"), Tag: sp("o1")},
+				{Scope: sp("cluster"), Tag: sp("c1")},
+			}
+			tags2 := []model.Tag{
+				{Scope: sp("owner"), Tag: sp("o1")},
+				{Scope: sp("cluster"), Tag: sp("c2")},
+			}
+			itemTags := []model.Tag{
+				{Scope: sp("owner"), Tag: sp("o1")},
+				{Scope: sp("cluster"), Tag: sp("c1")},
+				{Scope: sp("foo"), Tag: sp("bla")},
+				{Scope: sp("bar"), Tag: sp("xxx")},
+			}
+			Expect(mergeTags(tags1, tags1)).To(Equal(tags1))
+			Expect(mergeTags(tags1, tags2)).To(Equal(tags1))
+			Expect(mergeTags(tags2, tags1)).To(Equal(tags2))
+			Expect(mergeTags(itemTags, tags1)).To(Equal(itemTags))
+			Expect(mergeTags(tags1, itemTags)).To(Equal(itemTags))
+		})
+	})
 })
 
 func sp(s string) *string {


### PR DESCRIPTION
**What this PR does / why we need it**:
If additional tags are added to NSX-T objects created by the infrastructure controller,
they should be preserved.
Additionally, the handling of the network segment display name has been refactored.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
