### PR TITLE
infra-cli: accept yaml state file

### DIFF
--- a/pkg/cmd/infra-cli/destroy.go
+++ b/pkg/cmd/infra-cli/destroy.go
@@ -41,7 +41,7 @@ func DestroyInfrastructure(logger logr.Logger, cfg *infrastructure.NSXTConfig, s
 	var state *vsphere.NSXTInfraState
 	if stateString != nil {
 		state = &vsphere.NSXTInfraState{}
-		err = json.Unmarshal([]byte(*stateString), state)
+		err = yaml.Unmarshal([]byte(*stateString), state)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unmarshalling state failed")
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow to use infrastructure state file in YAML for the infra-cli  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Allow to use infrastructure state file in YAML for the infra-cli
```
