### PR TITLE
remove blocked-network cidr from kcm

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -84,9 +84,11 @@ func ensureKubeAPIServerCommandLineArgs(c *corev1.Container) {
 }
 
 func ensureKubeControllerManagerAnnotations(t *corev1.PodTemplateSpec) {
+	// make sure to always remove this label
+	delete(t.Labels, v1alpha1constants.LabelNetworkPolicyToBlockedCIDRs)
+
 	t.Labels = extensionswebhook.EnsureAnnotationOrLabel(t.Labels, v1alpha1constants.LabelNetworkPolicyToPublicNetworks, v1alpha1constants.LabelNetworkPolicyAllowed)
 	t.Labels = extensionswebhook.EnsureAnnotationOrLabel(t.Labels, v1alpha1constants.LabelNetworkPolicyToPrivateNetworks, v1alpha1constants.LabelNetworkPolicyAllowed)
-	t.Labels = extensionswebhook.EnsureAnnotationOrLabel(t.Labels, v1alpha1constants.LabelNetworkPolicyToBlockedCIDRs, v1alpha1constants.LabelNetworkPolicyAllowed)
 }
 
 func (e *ensurer) ensureChecksumAnnotations(ctx context.Context, template *corev1.PodTemplateSpec, namespace string) error {

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -67,7 +67,6 @@ var _ = Describe("Ensurer", func() {
 		kubeControllerManagerLabels = map[string]string{
 			v1alpha1constants.LabelNetworkPolicyToPublicNetworks:  v1alpha1constants.LabelNetworkPolicyAllowed,
 			v1alpha1constants.LabelNetworkPolicyToPrivateNetworks: v1alpha1constants.LabelNetworkPolicyAllowed,
-			v1alpha1constants.LabelNetworkPolicyToBlockedCIDRs:    v1alpha1constants.LabelNetworkPolicyAllowed,
 		}
 	)
 
@@ -159,6 +158,11 @@ var _ = Describe("Ensurer", func() {
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.DeploymentNameKubeControllerManager},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									v1alpha1constants.LabelNetworkPolicyToBlockedCIDRs: v1alpha1constants.LabelNetworkPolicyAllowed,
+								},
+							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
 									{
@@ -192,6 +196,11 @@ var _ = Describe("Ensurer", func() {
 					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1alpha1constants.DeploymentNameKubeControllerManager},
 					Spec: appsv1.DeploymentSpec{
 						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									v1alpha1constants.LabelNetworkPolicyToBlockedCIDRs: v1alpha1constants.LabelNetworkPolicyAllowed,
+								},
+							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
 									{


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes access to blocked networks from `kube-controller-manager`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`kube-controller-manageer` no longer has access to blocked CIDRs.
```
