### PR TITLE
allow to overwrite ensurer version for NSX-T infrastructure

### DIFF
--- a/cmd/infra-cli/main.go
+++ b/cmd/infra-cli/main.go
@@ -32,9 +32,9 @@ import (
 
 	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere"
 
+	api "github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/vsphere"
 	infra_cli "github.com/gardener/gardener-extension-provider-vsphere/pkg/cmd/infra-cli"
 	"github.com/gardener/gardener-extension-provider-vsphere/pkg/vsphere/infrastructure"
-	"github.com/gardener/gardener-extension-provider-vsphere/pkg/vsphere/infrastructure/ensurer"
 )
 
 var (
@@ -211,10 +211,10 @@ func createInfra(cmd *cobra.Command, args []string) {
 	switch stateVersion {
 	case "":
 		fixedVersion = nil
-	case ensurer.Version1_NSXT25, ensurer.Version2_NSXT30:
+	case api.Ensurer_Version1_NSXT25, api.Ensurer_Version2_NSXT30:
 		fixedVersion = &stateVersion
 	default:
-		panic(fmt.Errorf("invalid stateVersion (allowed: '%s', '%s')", ensurer.Version1_NSXT25, ensurer.Version2_NSXT30))
+		panic(fmt.Errorf("invalid stateVersion (allowed: %v)", api.SupportedEnsurerVersions))
 	}
 	resultingState, err := infra_cli.CreateInfrastructure(logger, config, string(spec), fixedVersion)
 	if resultingState != nil {

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -35,16 +35,26 @@ Here `base64(...)` are only a placeholders for the Base64 encoded values.
 The infrastructure configuration is currently not used. Nodes on all zones are using IP addresses from the common nodes
 network as the network is managed by NSX-T.
 
-An example `InfrastructureConfig` for the vSphere extension looks as follows (currently always empty):
+An example `InfrastructureConfig` for the vSphere extension looks as follows, but is currently only needed 
+to set advanced configuration values:
 
 ```yaml
 infrastructureConfig:
   apiVersion: vsphere.provider.extensions.gardener.cloud/v1alpha1
   kind: InfrastructureConfig
+  overwriteNSXTInfraVersion: '1'
 ```
 
 The infrastructure controller will create several network objects using NSX-T. A logical switch to be used as the network
-for the VMs (nodes), a tier-1 router, a DHCP server, and a SNAT for the nodes. 
+for the VMs (nodes), a tier-1 router, a DHCP server, and a SNAT for the nodes.
+
+### Advanced configuration settings
+
+The option `overwriteNSXTInfraVersion` can be used to change the network objects created during the initial infrastructure creation. 
+By default the infra-version is automatically selected according to the NSX-T version. The infra-version `'1'` is used 
+for NSX-T 2.5, and infra-version `'2'` for NSX-T versions >= 3.0. The difference is creation of the the logical DHCP server.
+For NSX-T 2.5, only the DHCP server of the "Advanced API" is usable. For NSX-T >= 3.0 the new DHCP server is default, 
+but for special purposes infra-version `'1'` is also allowed.
 
 ## `ControlPlaneConfig`
 
@@ -101,6 +111,7 @@ spec:
     #infrastructureConfig:
     #  apiVersion: vsphere.provider.extensions.gardener.cloud/v1alpha1
     #  kind: InfrastructureConfig
+    #  overwriteNSXTInfraVersion: '1'
 
     ## controlPlaneConfig has only optional parameters. Uncomment the following lines if needed
     #controlPlaneConfig:

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -251,6 +251,19 @@ string
 </td>
 <td><code>InfrastructureConfig</code></td>
 </tr>
+<tr>
+<td>
+<code>overwriteNSXTInfraVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>OverwriteNSXTInfraVersion allows to fix the ensurer version used to create the NSXT-T infrastructure.
+This is an advanced configuration to overwrite the automatic version selection.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="vsphere.provider.extensions.gardener.cloud/v1alpha1.WorkerStatus">WorkerStatus

--- a/pkg/apis/vsphere/types_infrastructure.go
+++ b/pkg/apis/vsphere/types_infrastructure.go
@@ -18,11 +18,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	Ensurer_Version1_NSXT25 = "1"
+	Ensurer_Version2_NSXT30 = "2"
+)
+
+var SupportedEnsurerVersions = []string{Ensurer_Version1_NSXT25, Ensurer_Version2_NSXT30}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // InfrastructureConfig infrastructure configuration resource
 type InfrastructureConfig struct {
 	metav1.TypeMeta
+	// OverwriteNSXTInfraVersion allows to fix the ensurer version used to create the NSXT-T infrastructure.
+	// This is an advanced configuration to overwrite the automatic version selection.
+	OverwriteNSXTInfraVersion *string
 }
 
 // VsphereConfig holds information about vSphere resources to use.

--- a/pkg/apis/vsphere/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/vsphere/v1alpha1/types_infrastructure.go
@@ -24,6 +24,10 @@ import (
 // InfrastructureConfig infrastructure configuration resource
 type InfrastructureConfig struct {
 	metav1.TypeMeta `json:",inline"`
+	// OverwriteNSXTInfraVersion allows to fix the ensurer version used to create the NSXT-T infrastructure.
+	// This is an advanced configuration to overwrite the automatic version selection.
+	// +optional
+	OverwriteNSXTInfraVersion *string `json:"overwriteNSXTInfraVersion,omitempty"`
 }
 
 // VsphereConfig holds information about vSphere resources to use.

--- a/pkg/apis/vsphere/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/vsphere/v1alpha1/zz_generated.conversion.go
@@ -431,6 +431,7 @@ func Convert_vsphere_FailureDomainLabels_To_v1alpha1_FailureDomainLabels(in *vsp
 }
 
 func autoConvert_v1alpha1_InfrastructureConfig_To_vsphere_InfrastructureConfig(in *InfrastructureConfig, out *vsphere.InfrastructureConfig, s conversion.Scope) error {
+	out.OverwriteNSXTInfraVersion = (*string)(unsafe.Pointer(in.OverwriteNSXTInfraVersion))
 	return nil
 }
 
@@ -440,6 +441,7 @@ func Convert_v1alpha1_InfrastructureConfig_To_vsphere_InfrastructureConfig(in *I
 }
 
 func autoConvert_vsphere_InfrastructureConfig_To_v1alpha1_InfrastructureConfig(in *vsphere.InfrastructureConfig, out *InfrastructureConfig, s conversion.Scope) error {
+	out.OverwriteNSXTInfraVersion = (*string)(unsafe.Pointer(in.OverwriteNSXTInfraVersion))
 	return nil
 }
 

--- a/pkg/apis/vsphere/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/vsphere/v1alpha1/zz_generated.deepcopy.go
@@ -248,6 +248,11 @@ func (in *FailureDomainLabels) DeepCopy() *FailureDomainLabels {
 func (in *InfrastructureConfig) DeepCopyInto(out *InfrastructureConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.OverwriteNSXTInfraVersion != nil {
+		in, out := &in.OverwriteNSXTInfraVersion, &out.OverwriteNSXTInfraVersion
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/vsphere/validation/infrastructure.go
+++ b/pkg/apis/vsphere/validation/infrastructure.go
@@ -18,15 +18,25 @@
 package validation
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	api "github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/vsphere"
 )
 
 // ValidateInfrastructureConfig validates a InfrastructureConfig object.
-func ValidateInfrastructureConfig(infra *api.InfrastructureConfig, nodesCIDR *string, fldPath *field.Path) field.ErrorList {
+func ValidateInfrastructureConfig(infra *api.InfrastructureConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+
+	if !isValidEnsurerVersion(infra.OverwriteNSXTInfraVersion) {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("overwriteNSXTInfraVersion"),
+			*infra.OverwriteNSXTInfraVersion, api.SupportedEnsurerVersions))
+	}
 	return allErrs
+}
+
+func isValidEnsurerVersion(version *string) bool {
+	return version == nil || sets.NewString(api.SupportedEnsurerVersions...).Has(*version)
 }
 
 // ValidateInfrastructureConfigUpdate validates a InfrastructureConfig object.

--- a/pkg/apis/vsphere/validation/infrastructure_test.go
+++ b/pkg/apis/vsphere/validation/infrastructure_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 
 	api "github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/vsphere"
 	. "github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/vsphere/validation"
@@ -39,6 +40,24 @@ var _ = Describe("InfrastructureConfig validation", func() {
 	})
 
 	Describe("#ValidateInfrastructureConfig", func() {
+		It("should return no errors for a valid configuration", func() {
+			Expect(ValidateInfrastructureConfig(infrastructureConfig, nilPath)).To(BeEmpty())
+		})
+
+		It("should check valid value for OverwriteNSXTInfraVersion", func() {
+			s := api.Ensurer_Version1_NSXT25
+			infrastructureConfig.OverwriteNSXTInfraVersion = &s
+			errorList := ValidateInfrastructureConfig(infrastructureConfig, nilPath)
+			Expect(errorList).To(BeEmpty())
+
+			s2 := "3"
+			infrastructureConfig.OverwriteNSXTInfraVersion = &s2
+			errorList = ValidateInfrastructureConfig(infrastructureConfig, nilPath)
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeNotSupported),
+				"Field": Equal("overwriteNSXTInfraVersion"),
+			}))))
+		})
 	})
 
 	Describe("#ValidateInfrastructureConfigUpdate", func() {

--- a/pkg/apis/vsphere/zz_generated.deepcopy.go
+++ b/pkg/apis/vsphere/zz_generated.deepcopy.go
@@ -248,6 +248,11 @@ func (in *FailureDomainLabels) DeepCopy() *FailureDomainLabels {
 func (in *InfrastructureConfig) DeepCopyInto(out *InfrastructureConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.OverwriteNSXTInfraVersion != nil {
+		in, out := &in.OverwriteNSXTInfraVersion, &out.OverwriteNSXTInfraVersion
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/cmd/infra-cli/create.go
+++ b/pkg/cmd/infra-cli/create.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 
-	"github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/vsphere"
 	"github.com/gardener/gardener-extension-provider-vsphere/pkg/vsphere/infrastructure"
 	"github.com/gardener/gardener-extension-provider-vsphere/pkg/vsphere/infrastructure/ensurer"
 )
@@ -37,14 +36,9 @@ func CreateInfrastructure(logger logr.Logger, cfg *infrastructure.NSXTConfig, sp
 	if err != nil {
 		return nil, errors.Wrapf(err, "unmarshalling spec failed")
 	}
-	state := &vsphere.NSXTInfraState{
-		Version: fixedVersion,
-	}
-	if fixedVersion == nil {
-		state, err = infrastructureEnsurer.NewStateWithVersion()
-		if err != nil {
-			return nil, errors.Wrapf(err, "NewStateWithVersion failed")
-		}
+	state, err := infrastructureEnsurer.NewStateWithVersion(fixedVersion)
+	if err != nil {
+		return nil, errors.Wrapf(err, "NewStateWithVersion failed")
 	}
 	err = infrastructureEnsurer.EnsureInfrastructure(spec, state)
 	stateString := showState(logger, state)

--- a/pkg/cmd/infra-cli/destroy.go
+++ b/pkg/cmd/infra-cli/destroy.go
@@ -46,7 +46,7 @@ func DestroyInfrastructure(logger logr.Logger, cfg *infrastructure.NSXTConfig, s
 			return nil, errors.Wrapf(err, "unmarshalling state failed")
 		}
 	} else {
-		state, err = infrastructureEnsurer.NewStateWithVersion()
+		state, err = infrastructureEnsurer.NewStateWithVersion(nil)
 		if err != nil {
 			return nil, errors.Wrapf(err, "NewStateWithVersion failed")
 		}

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -40,6 +40,7 @@ import (
 
 type preparedReconcile struct {
 	cloudProfileConfig *apisvsphere.CloudProfileConfig
+	infraConfig        *apisvsphere.InfrastructureConfig
 	region             *apisvsphere.RegionSpec
 	spec               infrastructure.NSXTInfraSpec
 	ensurer            infrastructure.NSXTInfrastructureEnsurer
@@ -47,6 +48,11 @@ type preparedReconcile struct {
 
 func (a *actuator) prepareReconcile(ctx context.Context, infra *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) (*preparedReconcile, error) {
 	cloudProfileConfig, err := apishelper.GetCloudProfileConfig(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	infraConfig, err := apishelper.GetInfrastructureConfig(cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -94,6 +100,7 @@ func (a *actuator) prepareReconcile(ctx context.Context, infra *extensionsv1alph
 
 	prepared := &preparedReconcile{
 		cloudProfileConfig: cloudProfileConfig,
+		infraConfig:        infraConfig,
 		region:             region,
 		spec:               spec,
 		ensurer:            infraEnsurer,
@@ -139,7 +146,7 @@ func (a *actuator) reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 	}
 
 	if state == nil {
-		state, err = prepared.ensurer.NewStateWithVersion()
+		state, err = prepared.ensurer.NewStateWithVersion(prepared.infraConfig.OverwriteNSXTInfraVersion)
 		if err != nil {
 			return errors.Wrapf(err, "NewStateWithVersion failed")
 		}

--- a/pkg/validator/shoot_validator.go
+++ b/pkg/validator/shoot_validator.go
@@ -97,7 +97,7 @@ func (v *Shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 func (v *Shoot) validateShoot(context *validationContext) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, vspherevalidation.ValidateNetworking(context.shoot.Spec.Networking, nwPath)...)
-	allErrs = append(allErrs, vspherevalidation.ValidateInfrastructureConfig(context.infraConfig, context.shoot.Spec.Networking.Nodes, infraConfigPath)...)
+	allErrs = append(allErrs, vspherevalidation.ValidateInfrastructureConfig(context.infraConfig, infraConfigPath)...)
 	allErrs = append(allErrs, vspherevalidation.ValidateControlPlaneConfig(context.cpConfig, cpConfigPath)...)
 	allErrs = append(allErrs, vspherevalidation.ValidateWorkers(context.shoot.Spec.Provider.Workers, workersPath)...)
 	return allErrs

--- a/pkg/vsphere/infrastructure/interface.go
+++ b/pkg/vsphere/infrastructure/interface.go
@@ -53,8 +53,8 @@ type NSXTConfig struct {
 type NSXTInfrastructureEnsurer interface {
 	// CheckConnection checks if the NSX-T REST API is reachable with the given endpoint and credentials.
 	CheckConnection() error
-	// NewStateWithVersion creates empty state with version depending on NSX-T backend
-	NewStateWithVersion() (*api.NSXTInfraState, error)
+	// NewStateWithVersion creates empty state with version depending on NSX-T backend or overwritten version
+	NewStateWithVersion(overwriteVersion *string) (*api.NSXTInfraState, error)
 	// EnsureInfrastructure ensures that the infrastructure is complete
 	// It checks all infrastructure objects and creates missing one or updates them if important attributes have been changed.
 	// It can even recover objects not recorded in the state.


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow to overwrite ensurer version for creation of NSX-T infrastructure per cloud profile.
This allows to test/evaluate different versions on the same NSX-T system.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
