### PR TITLE
update dependency cloud-provider-vsphere to support connection via proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ replace (
 )
 
 // only needed for infra-cli
-replace k8s.io/cloud-provider-vsphere => k8s.io/cloud-provider-vsphere v1.1.1-0.20200304125347-7d77c09fef97
+replace k8s.io/cloud-provider-vsphere => k8s.io/cloud-provider-vsphere v1.1.1-0.20200422163815-b564eaebdc17
 
 replace (
 	// these replacements are needed for the cloud-provider-vsphere

--- a/go.sum
+++ b/go.sum
@@ -1010,8 +1010,8 @@ k8s.io/autoscaler v0.0.0-20190805135949-100e91ba756e h1:5AX59ZgftHpbmNupSWosdtW4
 k8s.io/autoscaler v0.0.0-20190805135949-100e91ba756e/go.mod h1:QEXezc9uKPT91dwqhSJq3GNI3B1HxFRQHiku9kmrsSA=
 k8s.io/client-go v0.16.8 h1:CmsQXJpSWq1aUyQ5Lp/rRPiMK2OYfJv32Ftl0D1D42U=
 k8s.io/client-go v0.16.8/go.mod h1:WmPuN0yJTKHXoklExKxzo3jSXmr3EnN+65uaTb5VuNs=
-k8s.io/cloud-provider-vsphere v1.1.1-0.20200304125347-7d77c09fef97 h1:NHbLgefZZBV4yhTkiIeV9LrJCg/ky8VwEhcfVkqHVP0=
-k8s.io/cloud-provider-vsphere v1.1.1-0.20200304125347-7d77c09fef97/go.mod h1:nQH8reiSW+zHvU0F+xPfx9JDRKGndH5A3n44KljJo7I=
+k8s.io/cloud-provider-vsphere v1.1.1-0.20200422163815-b564eaebdc17 h1:Wm5mX6Cb8BN4ISgCgxO16Q6c9VLcrnQVRgY6d0oKFtE=
+k8s.io/cloud-provider-vsphere v1.1.1-0.20200422163815-b564eaebdc17/go.mod h1:nQH8reiSW+zHvU0F+xPfx9JDRKGndH5A3n44KljJo7I=
 k8s.io/code-generator v0.16.8 h1:R3NoYlz4AoTPvwOoDU0dTNV/P9uY3z8H8nLlz9nOo5M=
 k8s.io/code-generator v0.16.8/go.mod h1:wFdrXdVi/UC+xIfLi+4l9elsTT/uEF61IfcN2wOLULQ=
 k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/vendor/k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer/nsxt_broker.go
+++ b/vendor/k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer/nsxt_broker.go
@@ -128,6 +128,7 @@ func NewNsxtBroker(nsxtConfig *config.NsxtConfig) (NsxtBroker, error) {
 	}
 	httpClient := http.Client{
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsConfig,
 		},
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -958,7 +958,7 @@ k8s.io/client-go/util/workqueue
 # k8s.io/cloud-provider v0.0.0 => k8s.io/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20190615005809-e8462b5b5dc2
 k8s.io/cloud-provider
 k8s.io/cloud-provider/node/helpers
-# k8s.io/cloud-provider-vsphere v1.1.0 => k8s.io/cloud-provider-vsphere v1.1.1-0.20200304125347-7d77c09fef97
+# k8s.io/cloud-provider-vsphere v1.1.0 => k8s.io/cloud-provider-vsphere v1.1.1-0.20200422163815-b564eaebdc17
 k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere
 k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer
 k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer/config


### PR DESCRIPTION
**What this PR does / why we need it**:
The infra-cli command `destroy-loadbalancers` now supports NSX-T connection via proxy. This is needed, if the NSX-T Manager is only reachable via a HTTPS proxy. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
 infra-cli command 'destroy-loadbalancers': support NSX-T connection via proxy
```
