### PR TITLE
restrict cloud profile nameprefix to lower case alphanumeric and '-'

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -107,16 +107,14 @@ spec:
   provider:
     type: vsphere
    
-    ## infrastructureConfig is currently unused
     #infrastructureConfig:
     #  apiVersion: vsphere.provider.extensions.gardener.cloud/v1alpha1
     #  kind: InfrastructureConfig
     #  overwriteNSXTInfraVersion: '1'
 
-    ## controlPlaneConfig has only optional parameters. Uncomment the following lines if needed
-    #controlPlaneConfig:
-    #  apiVersion: vsphere.provider.extensions.gardener.cloud/v1alpha1
-    #  kind: ControlPlaneConfig
+    controlPlaneConfig:
+      apiVersion: vsphere.provider.extensions.gardener.cloud/v1alpha1
+      kind: ControlPlaneConfig
     #  loadBalancerClasses:
     #  - name: mylbclass
 

--- a/pkg/apis/vsphere/validation/cloudprofile.go
+++ b/pkg/apis/vsphere/validation/cloudprofile.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"fmt"
+	"regexp"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -25,6 +26,7 @@ import (
 )
 
 var validLoadBalancerSizeValues = sets.NewString("SMALL", "MEDIUM", "LARGE")
+var namePrefixPattern = regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
 
 // ValidateCloudProfileConfig validates a CloudProfileConfig object.
 func ValidateCloudProfileConfig(cloudProfile *apisvsphere.CloudProfileConfig) field.ErrorList {
@@ -42,6 +44,9 @@ func ValidateCloudProfileConfig(cloudProfile *apisvsphere.CloudProfileConfig) fi
 
 	if cloudProfile.NamePrefix == "" {
 		allErrs = append(allErrs, field.Required(field.NewPath("namePrefix"), "must provide name prefix for NSX-T resources"))
+	} else if !namePrefixPattern.MatchString(cloudProfile.NamePrefix) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("namePrefix"), cloudProfile.NamePrefix,
+			"must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"))
 	}
 	if cloudProfile.DefaultClassStoragePolicyName == "" {
 		allErrs = append(allErrs, field.Required(field.NewPath("defaultClassStoragePolicyName"), "must provide defaultClassStoragePolicyName"))

--- a/pkg/apis/vsphere/validation/cloudprofile_test.go
+++ b/pkg/apis/vsphere/validation/cloudprofile_test.go
@@ -30,7 +30,7 @@ var _ = Describe("ValidateCloudProfileConfig", func() {
 
 		BeforeEach(func() {
 			cloudProfileConfig = &apisvsphere.CloudProfileConfig{
-				NamePrefix:                    "prefix",
+				NamePrefix:                    "prefix-1",
 				DefaultClassStoragePolicyName: "default-class",
 				Constraints: apisvsphere.Constraints{
 					LoadBalancerConfig: apisvsphere.LoadBalancerConfig{
@@ -136,7 +136,9 @@ var _ = Describe("ValidateCloudProfileConfig", func() {
 					"Field": Equal("machineImages[0].versions[0].path"),
 				}))))
 			})
+		})
 
+		Context("load balancer validation", func() {
 			It("should have a load balancer size", func() {
 				cloudProfileConfig.Constraints.LoadBalancerConfig.Size = ""
 
@@ -159,7 +161,9 @@ var _ = Describe("ValidateCloudProfileConfig", func() {
 					"Field": Equal("constraints.loadBalancerConfig.size"),
 				}))))
 			})
+		})
 
+		Context("resources validation", func() {
 			It("should have a valid compute cluster/resource pool/host system", func() {
 				cloudProfileConfig.Regions[0].Zones[0].ResourcePool = nil
 
@@ -198,6 +202,25 @@ var _ = Describe("ValidateCloudProfileConfig", func() {
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
 					"Field": Equal("regions[0].zones[0].datacenter"),
+				}))))
+			})
+		})
+
+		Context("name prefix validation", func() {
+			It("should have a name prefix", func() {
+				cloudProfileConfig.NamePrefix = ""
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig)
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("namePrefix"),
+				}))))
+			})
+			It("should have a valid name prefix", func() {
+				cloudProfileConfig.NamePrefix = "gardener_dev"
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig)
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("namePrefix"),
 				}))))
 			})
 		})

--- a/pkg/vsphere/infrastructure/infraspec.go
+++ b/pkg/vsphere/infrastructure/infraspec.go
@@ -30,7 +30,7 @@ const (
 )
 
 func (s NSXTInfraSpec) FullClusterName() string {
-	return fmt.Sprintf("%s_%s", s.GardenName, s.ClusterName)
+	return fmt.Sprintf("%s--%s", s.GardenName, s.ClusterName)
 }
 
 func (s NSXTInfraSpec) CreateCommonTags() []common.Tag {

--- a/pkg/vsphere/infrastructure/task/tasks.go
+++ b/pkg/vsphere/infrastructure/task/tasks.go
@@ -409,6 +409,9 @@ func equivalentSingleSubnet(a []model.SegmentSubnet, b []model.SegmentSubnet) bo
 		return false
 	}
 
+	if a0.DhcpConfig == nil || b0.DhcpConfig == nil {
+		return a0.DhcpConfig == b0.DhcpConfig
+	}
 	converter := bindings.NewTypeConverter()
 	converter.SetMode(bindings.REST)
 	cfga0, err := converter.ConvertToGolang(a0.DhcpConfig, model.SegmentDhcpV4ConfigBindingType())


### PR DESCRIPTION
**What this PR does / why we need it**:
The name prefix defined in the cloud profile config is restricted to lower case alphanumeric and '-'.
The network names are restricted to lower case alphanumeric in the VMware Tanzu vmoperator.
We want to use the Tanzu vmoperator for creating worker node VMs in the future.
The network name corresponds to the NSX-T segment name, which like all created NSX-T infrastructure objects use the name prefix in the name. It is therefore needed to restrict the name prefix and also replace the '_' between the name prefix and shoot name with '--'.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
