### PR TITLE
Remove NoExecute toleration from CCM

### DIFF
--- a/charts/internal/seed-controlplane/charts/vsphere-cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/vsphere-cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -33,9 +33,6 @@ spec:
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}
     spec:
-      tolerations:
-      - effect: NoExecute
-        operator: Exists
       containers:
       - name: vsphere-cloud-controller-manager
         image: {{ index .Values.images "vsphere-cloud-controller-manager" }}


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind bug
/priority normal
/platform vsphere

**What this PR does / why we need it**:
Removes the `NoExecute` toleration from components running in the Seed cluster, such as the CCM. This toleration should not be needed for such components, see the discussion in https://github.com/gardener/gardener-extension-provider-azure/pull/120.

**Release note**:
```improvement operator
NONE
```