### PR TITLE
clean up possible orphan load balancer objects during deleting the infrastructure

### DIFF
--- a/cmd/infra-cli/main.go
+++ b/cmd/infra-cli/main.go
@@ -34,6 +34,7 @@ import (
 
 	api "github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/vsphere"
 	infra_cli "github.com/gardener/gardener-extension-provider-vsphere/pkg/cmd/infra-cli"
+	"github.com/gardener/gardener-extension-provider-vsphere/pkg/cmd/infra-cli/loadbalancer"
 	"github.com/gardener/gardener-extension-provider-vsphere/pkg/vsphere/infrastructure"
 )
 
@@ -94,7 +95,7 @@ func init() {
                It uses the cleanup functionality and needs the cluster name, IP pool name and owner tag`,
 	}
 	destroyLBCmd.Flags().StringVar(&clusterName, "clusterName", "", "cluster name as tagged in NSX-T load balancer objects")
-	destroyLBCmd.Flags().StringVar(&ipPoolName, "ipPoolName", "", "IP pool name")
+	destroyLBCmd.Flags().StringVar(&ipPoolName, "ipPoolName", "", "(default) IP pool name")
 	destroyLBCmd.Flags().StringVar(&owner, "owner", "", "owner tag")
 	destroyLBCmd.Run = destroyLoadBalancers
 	rootCmd.AddCommand(destroyLBCmd)
@@ -307,7 +308,12 @@ func destroyLoadBalancers(cmd *cobra.Command, args []string) {
 	if owner == "" {
 		panic("missing owner for destroying load balancers")
 	}
-	err := infra_cli.DestroyLoadBalancers(config, clusterName, ipPoolName, owner)
+	state := &loadbalancer.DestroyState{
+		ClusterName:       clusterName,
+		Owner:             owner,
+		DefaultIPPoolName: ipPoolName,
+	}
+	err := loadbalancer.DestroyAll(config, state)
 	if err != nil {
 		panic(errors.Wrapf(err, "DestroyInfrastructure failed"))
 	}

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ replace (
 )
 
 // only needed for infra-cli
-replace k8s.io/cloud-provider-vsphere => github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200522092937-0ba091f72743
+replace k8s.io/cloud-provider-vsphere => github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200626142015-33b0a5766b2c
 
 replace (
 	// these replacements are needed for the cloud-provider-vsphere

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20181220005116-f8e995905100/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
-github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200522092937-0ba091f72743 h1:doVWmrUA3lxa5ZuvEdGLwipaiJx4gQzecDWEgOugAoY=
-github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200522092937-0ba091f72743/go.mod h1:pUR2h4XvuzRIse3vjBSPHMmTCzJFitZP3fOLqZox5Y0=
+github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200626142015-33b0a5766b2c h1:9T+Nspr9z8Xn3T5nzpJunIwQwu3lwXrtlQYVQAQQTL4=
+github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200626142015-33b0a5766b2c/go.mod h1:pUR2h4XvuzRIse3vjBSPHMmTCzJFitZP3fOLqZox5Y0=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -16,9 +16,12 @@ package infrastructure
 
 import (
 	"context"
+	"fmt"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
+	"github.com/gardener/gardener-extension-provider-vsphere/pkg/cmd/infra-cli/loadbalancer"
 )
 
 func (a *actuator) delete(ctx context.Context, infra *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) error {
@@ -34,6 +37,20 @@ func (a *actuator) delete(ctx context.Context, infra *extensionsv1alpha1.Infrast
 	prepared, err := a.prepareReconcile(ctx, infra, cluster)
 	if err != nil {
 		return err
+	}
+
+	// try to cleanup any possible left-offs from the cloud-provider-vsphere load balancer controller
+	ipPoolName, err := prepared.getDefaultLoadBalancerIPPoolName()
+	if err == nil {
+		lbstate := &loadbalancer.DestroyState{
+			ClusterName:       cluster.ObjectMeta.Namespace + "-" + a.gardenID,
+			Owner:             a.gardenID,
+			DefaultIPPoolName: *ipPoolName,
+		}
+		err = loadbalancer.DestroyAll(prepared.nsxtConfig, lbstate)
+	}
+	if err != nil {
+		a.logger.Info(fmt.Sprintf("warning: cleanup of load balancers failed with: %s", err), "infra", infra.Name)
 	}
 
 	err = prepared.ensurer.EnsureInfrastructureDeleted(&prepared.spec, state)

--- a/vendor/k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer/cleanup.go
+++ b/vendor/k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer/cleanup.go
@@ -99,7 +99,7 @@ func (p *lbProvider) CleanupServices(clusterName string, validServices map[types
 	}
 
 	lbs := map[types.NamespacedName]struct{}{}
-	servers, err := p.access.ListVirtualServers(ClusterName)
+	servers, err := p.access.ListVirtualServers(clusterName)
 	if err != nil {
 		return err
 	}

--- a/vendor/k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer/config/config.go
+++ b/vendor/k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer/config/config.go
@@ -75,16 +75,21 @@ type LoadBalancerClassConfig struct {
 
 // NsxtConfig contains the NSX-T specific configuration
 type NsxtConfig struct {
-	// NSX-T username.
+	// NSX-T username (either with role `Enterprise Admin` or `LB Admin`)
 	User string `gcfg:"user"`
 	// NSX-T password in clear text.
 	Password string `gcfg:"password"`
 	// NSX-T host.
 	Host string `gcfg:"host"`
+	// NSX-T username for ip pool address allocation (with role `Network Engineer`). Only needed if `User` has role `LB Admin`
+	UserNE string `gcfg:"userNE"`
+	// NSX-T password in clear text.
+	PasswordNE string `gcfg:"passwordNE"`
+	// NSX-T host.
 	// InsecureFlag is to be set to true if NSX-T uses self-signed cert.
 	InsecureFlag bool `gcfg:"insecure-flag"`
 	// RemoteAuth is to be set to true if NSX-T uses remote authentication (authentication done through the vIDM).
-	RemoteAuth bool `json:"remote-auth,omitempty"`
+	RemoteAuth bool `gcfg:"remote-auth"`
 
 	VMCAccessToken     string `gcfg:"vmcAccessToken"`
 	VMCAuthHost        string `gcfg:"vmcAuthHost"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -959,7 +959,7 @@ k8s.io/client-go/util/workqueue
 # k8s.io/cloud-provider v0.0.0 => k8s.io/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20190615005809-e8462b5b5dc2
 k8s.io/cloud-provider
 k8s.io/cloud-provider/node/helpers
-# k8s.io/cloud-provider-vsphere v1.1.0 => github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200522092937-0ba091f72743
+# k8s.io/cloud-provider-vsphere v1.1.0 => github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200626142015-33b0a5766b2c
 k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere
 k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer
 k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer/config


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area control-plane
/area robustness
/kind enhancement
/priority normal
/platform vmware

**What this PR does / why we need it**:
If for any reasons the load balancers are not cleaned up by the cloud controller manager,
they are cleaned up during deleting the infrastructure.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
clean up possible orphan load balancer objects during deleting the infrastructure
```
