### PR TITLE
ignore if gateway locale service has already disappeared

### DIFF
--- a/pkg/vsphere/infrastructure/task/tasks.go
+++ b/pkg/vsphere/infrastructure/task/tasks.go
@@ -306,7 +306,7 @@ type tier1GatewayLocaleServiceTask struct{ baseTask }
 var _ RecoverableTask = &tier1GatewayLocaleServiceTask{}
 
 func NewTier1GatewayLocaleServiceTask() Task {
-	return &tier1GatewayLocaleServiceTask{baseTask{label: "tier-1 gateway local service"}}
+	return &tier1GatewayLocaleServiceTask{baseTask{label: "tier-1 gateway locale service"}}
 }
 
 func (t *tier1GatewayLocaleServiceTask) Reference(state *api.NSXTInfraState) *api.Reference {
@@ -386,7 +386,10 @@ func (t *tier1GatewayLocaleServiceTask) EnsureDeleted(ctx EnsurerContext, state 
 	}
 	err := client.Delete(state.LocaleServiceRef.ID, defaultPolicyLocaleServiceID)
 	if err != nil {
-		return false, nicerVAPIError(err)
+		_, err2 := client.Get(state.LocaleServiceRef.ID, defaultPolicyLocaleServiceID)
+		if !isNotFoundError(err2) {
+			return false, nicerVAPIError(err)
+		}
 	}
 	state.LocaleServiceRef = nil
 	return true, nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area robustness
/kind enhancement
/priority normal
/platform vmware

**What this PR does / why we need it**:
For unclear reasons the deletion of the Tier1 gateway locale service sometimes fails. On subsequent retries, the deletion is not successful, as the service object is not existing anymore.
With this PR, in this case it is checked after failed deletion, if the locale service still exists. If not, the deletion tasks just succeeds without any further action.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
