### PR TITLE
Restrict clusterID used for CSI to 63 characters

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -36,24 +36,12 @@ images:
 - name: vsphere-csi-driver-controller
   sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   repository: gcr.io/cloud-provider-vsphere/csi/release/driver
-  tag: v1.0.2
+  tag: v2.0.0
 - name: vsphere-csi-driver-node
   sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   repository: gcr.io/cloud-provider-vsphere/csi/release/driver
-  tag: v1.0.2
+  tag: v2.0.0
 - name: vsphere-csi-driver-syncer
-  sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
-  repository: gcr.io/cloud-provider-vsphere/csi/release/syncer
-  tag: v1.0.2
-- name: new-vsphere-csi-driver-controller
-  sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
-  repository: gcr.io/cloud-provider-vsphere/csi/release/driver
-  tag: v2.0.0
-- name: new-vsphere-csi-driver-node
-  sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
-  repository: gcr.io/cloud-provider-vsphere/csi/release/driver
-  tag: v2.0.0
-- name: new-vsphere-csi-driver-syncer
   sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   repository: gcr.io/cloud-provider-vsphere/csi/release/syncer
   tag: v2.0.0

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/vsphere-csi-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/vsphere-csi-controller.yaml
@@ -78,71 +78,8 @@ spec:
             - name: csi-resizer
               mountPath: /var/lib/csi-resizer
 {{- end }}
-{{- if .Values.csi2 }}
-        - name: vsphere-csi-controller
-          image: {{ index .Values.images "new-vsphere-csi-driver-controller" }}
-          env:
-            - name: KUBECONFIG
-              value: /var/lib/vsphere-csi-controller/kubeconfig
-            - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-            - name: X_CSI_MODE
-              value: "controller"
-            - name: VSPHERE_CSI_CONFIG
-              value: "/etc/cloud/csi-vsphere.conf"
-            - name: LOGGER_LEVEL
-              value: "{{ .Values.loggerLevel }}" # Options: DEVELOPMENT, PRODUCTION
-{{- if .Values.resources.controller }}
-          resources:
-{{ toYaml .Values.resources.controller | indent 12 }}
-{{- end }}
-          volumeMounts:
-            - mountPath: /etc/cloud
-              name: vsphere-config-volume
-              readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
-              name: socket-dir
-            - name: vsphere-csi-controller
-              mountPath: /var/lib/vsphere-csi-controller
-          ports:
-            - name: healthz
-              containerPort: 9808
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: healthz
-            initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 5
-            failureThreshold: 3
-        - name: vsphere-syncer
-          image: {{ index .Values.images "new-vsphere-csi-driver-syncer" }}
-          args:
-            - "--leader-election"
-            - "--kubeconfig=/var/lib/csi-syncer/kubeconfig"
-          env:
-            - name: FULL_SYNC_INTERVAL_MINUTES
-              value: "30"
-            - name: VSPHERE_CSI_CONFIG
-              value: "/etc/cloud/csi-vsphere.conf"
-            - name: LOGGER_LEVEL
-              value: "{{ .Values.loggerLevel }}" # Options: DEVELOPMENT, PRODUCTION
-{{- if .Values.resources.syncer }}
-          resources:
-{{ toYaml .Values.resources.syncer | indent 12 }}
-{{- end }}
-          volumeMounts:
-            - name: csi-syncer
-              mountPath: /var/lib/csi-syncer
-            - mountPath: /etc/cloud
-              name: vsphere-config-volume
-              readOnly: true
-{{- else }}
         - name: vsphere-csi-controller
           image: {{ index .Values.images "vsphere-csi-driver-controller" }}
-          args:
-            - "--v=4"
           env:
             - name: KUBECONFIG
               value: /var/lib/vsphere-csi-controller/kubeconfig
@@ -152,6 +89,8 @@ spec:
               value: "controller"
             - name: VSPHERE_CSI_CONFIG
               value: "/etc/cloud/csi-vsphere.conf"
+            - name: LOGGER_LEVEL
+              value: "{{ .Values.loggerLevel }}" # Options: DEVELOPMENT, PRODUCTION
 {{- if .Values.resources.controller }}
           resources:
 {{ toYaml .Values.resources.controller | indent 12 }}
@@ -179,7 +118,7 @@ spec:
         - name: vsphere-syncer
           image: {{ index .Values.images "vsphere-csi-driver-syncer" }}
           args:
-            - "--v=2"
+            - "--leader-election"
             - "--kubeconfig=/var/lib/csi-syncer/kubeconfig"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
@@ -198,7 +137,6 @@ spec:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
               readOnly: true
-{{- end }}
         - name: liveness-probe
           image: {{ index .Values.images "liveness-probe" }}
           args:

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/values.yaml
@@ -5,8 +5,6 @@ images:
   csi-provisioner: image-repository:image-tag
   vsphere-csi-driver-controller: image-repository:image-tag
   vsphere-csi-driver-syncer: image-repository:image-tag
-  new-vsphere-csi-driver-controller: image-repository:image-tag-new
-  new-vsphere-csi-driver-syncer: image-repository:image-tag-new
   liveness-probe: image-repository:image-tag
 podAnnotations: {}
 serverName: my.vcenter.server.ip.or.fqdn
@@ -17,7 +15,6 @@ port: 443
 datacenters: dc1
 insecureFlag: true
 resizerEnabled: false
-csi2: false
 loggerLevel: PRODUCTION
 resources:
   attacher:

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
@@ -52,11 +52,7 @@ spec:
         - name: registration-dir
           mountPath: /registration
       - name: vsphere-csi-node
-  {{- if .Values.csi2 }}
-        image: {{ index .Values.images "new-vsphere-csi-driver-node" }}
-  {{- else }}
         image: {{ index .Values.images "vsphere-csi-driver-node" }}
-  {{- end }}
         env:
         - name: NODE_NAME
           valueFrom:

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/values.yaml
@@ -1,6 +1,5 @@
 images:
   vsphere-csi-driver-node: image-repository:image-tag
-  new-vsphere-csi-driver-node: image-repository:image-tag-new
   csi-driver-registrar: image-repository:image-tag
   liveness-probe: image-repository:image-tag
 serverName: my.vcenter.server.ip.or.fqdn
@@ -12,4 +11,3 @@ datacenters: dc1
 insecureFlag: true
 # topology-aware setup
 topologyAware: true
-csi2: false

--- a/go.mod
+++ b/go.mod
@@ -19,9 +19,9 @@ require (
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5
 	github.com/vmware/go-vmware-nsxt v0.0.0-20200114231430-33a5af043f2e
-	github.com/vmware/vsphere-automation-sdk-go/lib v0.2.0
-	github.com/vmware/vsphere-automation-sdk-go/runtime v0.2.0
-	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.3.0
+	github.com/vmware/vsphere-automation-sdk-go/lib v0.3.1
+	github.com/vmware/vsphere-automation-sdk-go/runtime v0.3.1
+	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.4.0
 	k8s.io/api v0.17.9
 	k8s.io/apiextensions-apiserver v0.17.9
 	k8s.io/apimachinery v0.17.9

--- a/go.sum
+++ b/go.sum
@@ -719,10 +719,16 @@ github.com/vmware/photon-controller-go-sdk v0.0.0-20170310013346-4a435daef6cc/go
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/vmware/vsphere-automation-sdk-go/lib v0.2.0 h1:noiASkafwxvCmmCtZK0f1pt06R8c+Fkt9TcZW7xpYy0=
 github.com/vmware/vsphere-automation-sdk-go/lib v0.2.0/go.mod h1://FsAiCrr+T/Eq2Uxtq8UPVPbZWV7iLIvvXK17rsIxE=
+github.com/vmware/vsphere-automation-sdk-go/lib v0.3.1 h1:YIcvcshkKm/fbXOvheGfAlGlDTitQXUSMPnYON/uzyg=
+github.com/vmware/vsphere-automation-sdk-go/lib v0.3.1/go.mod h1:lzuoOgc7zhx3bfrKFRDBbaJX3wj4wSstWv4pTpryhJs=
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.2.0 h1:AM5AK9cyiJWFIfxrh1U/kuRFh+A2pymCEGiXqAkPzzw=
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.2.0/go.mod h1:M6pTKDrJrPlVG++lboLRf0bDYc3TJ2fsR+KOoWXfCns=
+github.com/vmware/vsphere-automation-sdk-go/runtime v0.3.1 h1:AhoRilMJ6hZbBDr4J9GSrAVpPBkLlZz8+FS84Pdbhc8=
+github.com/vmware/vsphere-automation-sdk-go/runtime v0.3.1/go.mod h1:kYY+E5osoSMD814W25lc8SqHqSo32hbCZr4pFRA5VgA=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.3.0 h1:Ekf0/umhKdr4N0oURDFlkhZHVm6w0eXzbsn6yc/vL+4=
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.3.0/go.mod h1:k9tf91B5Ah7gkaM2s+Z6nATmn6gKmgt8AqJ8RUiKLfo=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.4.0 h1:umuvIi9YYb3TIS3uwtoTyEG1Fp1cfvNxTL0rolVU6eI=
+github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.4.0/go.mod h1:wZ/NNI0WCtAPnfrh2hq/IBjxXsWg0oxD4nnr6vitl/8=
 github.com/xanzy/go-cloudstack v0.0.0-20160728180336-1e2cbf647e57/go.mod h1:s3eL3z5pNXF5FVybcT+LIVdId8pYn709yv6v5mrkrQE=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
@@ -847,6 +853,8 @@ golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3ob
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200602114024-627f9648deb9 h1:pNX+40auqi2JqRfOP1akLGtYcn15TUbkhwuCO3foqqM=
+golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -301,7 +301,6 @@ insecure-flag = "true"
 				"serverPort":        443,
 				"datacenters":       "scc01-DC",
 				"insecureFlag":      "true",
-				"csi2":              true,
 				"resizerEnabled":    true,
 				"podAnnotations": map[string]interface{}{
 					"checksum/secret-" + vsphere.CSIProvisionerName:               "f75b42d40ab501428c383dfb2336cb1fc892bbee1fc1d739675171e4acc4d911",
@@ -324,7 +323,6 @@ insecure-flag = "true"
 				"serverPort":        443,
 				"datacenters":       "scc01-DC",
 				"insecureFlag":      "true",
-				"csi2":              true,
 				"kubernetesVersion": "1.14.0",
 			},
 		}
@@ -392,6 +390,27 @@ insecure-flag = "true"
 			Expect(values).To(Equal(controlPlaneShootChartValues))
 		})
 	})
+
+	Describe("#shortenID", func() {
+		It("should shorten ID to given max length", func() {
+			id1 := "shoot--garden--something12-cf7607c1-1b8a-11e8-8c77-fa163e4902b1"
+			id2 := "shoot--garden--something123-cf7607c1-1b8a-11e8-8c77-fa163e4902b1"
+			id3 := "shoot--garden--something123-cf7607c1-1b8a-11e8-8c77-fa163e4902b2"
+			id4 := "shoot--garden--something1234-cf7607c1-1b8a-11e8-8c77-fa163e4902b1"
+
+			short1 := shortenID(id1, 63)
+			short2 := shortenID(id2, 63)
+			short3 := shortenID(id3, 63)
+			short4 := shortenID(id4, 63)
+			Expect(short1).To(Equal(id1))
+			Expect(short2).To(Equal("shoot--garden--something123-cf7607c1-1b8a-11e8-8c7-qksvc0j2gs99"))
+			Expect(len(short2)).To(Equal(63))
+			Expect(short3).To(Equal("shoot--garden--something123-cf7607c1-1b8a-11e8-8c7-qksvc0j2gs9a"))
+			Expect(short4).To(Equal("shoot--garden--something1234-cf7607c1-1b8a-11e8-8c-8wzf59wac3mj"))
+			Expect(len(short4)).To(Equal(63))
+		})
+	})
+
 })
 
 func encode(obj runtime.Object) []byte {

--- a/pkg/vsphere/infrastructure/ensurer/get_nsxt_version.go
+++ b/pkg/vsphere/infrastructure/ensurer/get_nsxt_version.go
@@ -49,7 +49,7 @@ func getNSXTVersion(connector client.Connector) (*string, error) {
 		dispatchHeaderParams := map[string]string{}
 		bodyFieldsMap := map[string]string{}
 		resultHeaders := map[string]string{}
-		errorHeaders := map[string]string{}
+		errorHeaders := map[string]map[string]string{}
 		return protocol.NewOperationRestMetadata(
 			fields,
 			fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/StdPackageTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/StdPackageTypes.go
@@ -15,6 +15,8 @@ package std
 import (
 	"reflect"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/log"
 	"time"
 )
 
@@ -102,6 +104,23 @@ const AuthenticationScheme_USER_PASSWORD = "com.vmware.vapi.std.security.user_pa
 //  vAPI runtime provides convenient factory methods that takes OAuth2 access token as input parameter and creates a security context that conforms to the above format.
 const AuthenticationScheme_OAUTH_ACCESS_TOKEN = "com.vmware.vapi.std.security.oauth"
 
+func (s AuthenticationScheme) GetType__() bindings.BindingType {
+	return AuthenticationSchemeBindingType()
+}
+
+func (s AuthenticationScheme) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for AuthenticationScheme._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
+
 // The ``DynamicID`` class represents an identifier for a resource of an arbitrary type.
 type DynamicID struct {
     // The type of resource being identified (for example ``com.acme.Person``). 
@@ -111,6 +130,23 @@ type DynamicID struct {
     // The identifier for a resource whose type is specified by DynamicID#type.
 	Id string
 }
+
+func (s DynamicID) GetType__() bindings.BindingType {
+	return DynamicIDBindingType()
+}
+
+func (s DynamicID) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for DynamicID._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``LocalizableMessage`` class represents localizable string and message template. Interfaces include one or more localizable message templates in the exceptions they report so that clients can display diagnostic messages in the native language of the user. Interfaces can include localizable strings in the data returned from methods to allow clients to display localized status information in the native language of the user.
 type LocalizableMessage struct {
@@ -127,6 +163,23 @@ type LocalizableMessage struct {
     // Localized string value as per request requirements.
 	Localized *string
 }
+
+func (s LocalizableMessage) GetType__() bindings.BindingType {
+	return LocalizableMessageBindingType()
+}
+
+func (s LocalizableMessage) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for LocalizableMessage._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // This class holds a single message parameter and formatting settings for it. The class has fields for string, int64, float64, date time and nested messages. Only one will be used depending on the type of data sent. For date, float64 and int64 it is possible to set additional formatting details.
 type LocalizationParam struct {
@@ -145,6 +198,23 @@ type LocalizationParam struct {
     // Number of fractional digits to include in formatted float64 value.
 	Precision *int64
 }
+
+func (s LocalizationParam) GetType__() bindings.BindingType {
+	return LocalizationParamBindingType()
+}
+
+func (s LocalizationParam) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for LocalizationParam._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``DateTimeFormat`` enumeration class lists possible date and time formatting options. It combines the Unicode CLDR format types - full, long, medium and short with 3 different presentations - date only, time only and combined date and time presentation.
 //
@@ -219,6 +289,23 @@ type NestedLocalizableMessage struct {
     // Named Arguments to be substituted into the message template.
 	Params map[string]LocalizationParam
 }
+
+func (s NestedLocalizableMessage) GetType__() bindings.BindingType {
+	return NestedLocalizableMessageBindingType()
+}
+
+func (s NestedLocalizableMessage) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for NestedLocalizableMessage._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 
 

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors/ErrorsPackageTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors/ErrorsPackageTypes.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/log"
 	"github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std"
 )
 
@@ -50,6 +51,23 @@ func (AlreadyExists AlreadyExists) Error() string {
 	return "com.vmware.vapi.std.errors.already_exists"
 }
 
+func (s AlreadyExists) GetType__() bindings.BindingType {
+	return AlreadyExistsBindingType()
+}
+
+func (s AlreadyExists) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for AlreadyExists._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
+
 // The ``AlreadyInDesiredState`` exception indicates that an attempt to change the state of a resource or service had no effect because the resource or service is already in the desired state. 
 //
 //  Examples: 
@@ -77,6 +95,23 @@ func (AlreadyInDesiredState AlreadyInDesiredState) Error() string {
 	return "com.vmware.vapi.std.errors.already_in_desired_state"
 }
 
+func (s AlreadyInDesiredState) GetType__() bindings.BindingType {
+	return AlreadyInDesiredStateBindingType()
+}
+
+func (s AlreadyInDesiredState) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for AlreadyInDesiredState._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
+
 // The ``ArgumentLocations`` class describes which part(s) of the input to the method caused the exception. 
 //
 //  Some types of exceptions are caused by the value of one of the inputs to the method, possibly due to an interaction with other inputs to the method. This class is intended to be used as the payload to identify those inputs when the method reports exceptions like InvalidArgument or NotFound. See Error#data.
@@ -86,6 +121,23 @@ type ArgumentLocations struct {
     // Array (possibly empty) of strings describing the locations of other inputs that caused the the primary input to trigger the exception.
 	Secondary []string
 }
+
+func (s ArgumentLocations) GetType__() bindings.BindingType {
+	return ArgumentLocationsBindingType()
+}
+
+func (s ArgumentLocations) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for ArgumentLocations._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``Canceled`` exception indicates that the method canceled itself in response to an explicit request to do so. Methods being "canceled" for other reasons (for example the client connection was closed, a time out occured, or due to excessive resource consumption) should not report this exception. 
 //
@@ -122,6 +174,23 @@ func (Canceled Canceled) Error() string {
 	return "com.vmware.vapi.std.errors.canceled"
 }
 
+func (s Canceled) GetType__() bindings.BindingType {
+	return CanceledBindingType()
+}
+
+func (s Canceled) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for Canceled._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
+
 // The ``ConcurrentChange`` exception indicates that a data structure, entity, or resource has been modified since some earlier point in time. Typically this happens when the client is doing the *write* portion of a read-modify-write sequence and indicates that it wants the server to notify it if the data in the server has changed after it did the *read*, so that it can avoid overwriting that change inadvertantly.
 type ConcurrentChange struct {
     // Stack of one or more localizable messages for human exception consumers. 
@@ -144,6 +213,23 @@ func NewConcurrentChange() *ConcurrentChange {
 func (ConcurrentChange ConcurrentChange) Error() string {
 	return "com.vmware.vapi.std.errors.concurrent_change"
 }
+
+func (s ConcurrentChange) GetType__() bindings.BindingType {
+	return ConcurrentChangeBindingType()
+}
+
+func (s ConcurrentChange) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for ConcurrentChange._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``Error`` exception describes theproperties common to all standard exceptions. 
 //
@@ -172,6 +258,23 @@ func NewError() *Error {
 func (Error Error) Error() string {
 	return "com.vmware.vapi.std.errors.error"
 }
+
+func (s Error) GetType__() bindings.BindingType {
+	return ErrorBindingType()
+}
+
+func (s Error) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for Error._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // Enumeration of all standard errors. Used as discriminator in protocols that have no standard means for transporting the error type, e.g. REST.
 //
@@ -317,6 +420,23 @@ func (FeatureInUse FeatureInUse) Error() string {
 	return "com.vmware.vapi.std.errors.feature_in_use"
 }
 
+func (s FeatureInUse) GetType__() bindings.BindingType {
+	return FeatureInUseBindingType()
+}
+
+func (s FeatureInUse) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for FeatureInUse._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
+
 // The ``FileLocations`` class identifies the file(s) that caused the method to report the exception. 
 //
 //  Some types of exceptions are caused by a problem with one or more files. This class is intended to be used as the payload to identify those files when the method reports exceptions like NotFound. See Error#data.
@@ -326,6 +446,23 @@ type FileLocations struct {
     // Array (possibly empty) of strings identifying other files that caused the primary file to trigger the exception.
 	Secondary []string
 }
+
+func (s FileLocations) GetType__() bindings.BindingType {
+	return FileLocationsBindingType()
+}
+
+func (s FileLocations) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for FileLocations._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``InternalServerError`` exception indicates that the server encounters an unexpected condition that prevented it from fulfilling the request. 
 //
@@ -356,6 +493,23 @@ func NewInternalServerError() *InternalServerError {
 func (InternalServerError InternalServerError) Error() string {
 	return "com.vmware.vapi.std.errors.internal_server_error"
 }
+
+func (s InternalServerError) GetType__() bindings.BindingType {
+	return InternalServerErrorBindingType()
+}
+
+func (s InternalServerError) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for InternalServerError._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``InvalidArgument`` exception indicates that the values received for one or more parameters are not acceptable. 
 //
@@ -398,6 +552,23 @@ func (InvalidArgument InvalidArgument) Error() string {
 	return "com.vmware.vapi.std.errors.invalid_argument"
 }
 
+func (s InvalidArgument) GetType__() bindings.BindingType {
+	return InvalidArgumentBindingType()
+}
+
+func (s InvalidArgument) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for InvalidArgument._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
+
 // The ``InvalidElementConfiguration`` exception indicates that an attempt to modify the configuration of an element or a group containing the element failed due to the configuraton of the element. A typical case is when the method is am attempt to change the group membership of the element fails, in which case a configuration change on the element may allow the group membership change to succeed. 
 //
 //  Examples: 
@@ -425,6 +596,23 @@ func NewInvalidElementConfiguration() *InvalidElementConfiguration {
 func (InvalidElementConfiguration InvalidElementConfiguration) Error() string {
 	return "com.vmware.vapi.std.errors.invalid_element_configuration"
 }
+
+func (s InvalidElementConfiguration) GetType__() bindings.BindingType {
+	return InvalidElementConfigurationBindingType()
+}
+
+func (s InvalidElementConfiguration) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for InvalidElementConfiguration._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``InvalidElementType`` exception indicates that the server was unable to fulfil the request because an element of a specific type cannot be a member of particular group. 
 //
@@ -459,6 +647,23 @@ func NewInvalidElementType() *InvalidElementType {
 func (InvalidElementType InvalidElementType) Error() string {
 	return "com.vmware.vapi.std.errors.invalid_element_type"
 }
+
+func (s InvalidElementType) GetType__() bindings.BindingType {
+	return InvalidElementTypeBindingType()
+}
+
+func (s InvalidElementType) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for InvalidElementType._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``InvalidRequest`` exception indicates that the request is malformed in such a way that the server is unable to process it. 
 //
@@ -502,6 +707,23 @@ func (InvalidRequest InvalidRequest) Error() string {
 	return "com.vmware.vapi.std.errors.invalid_request"
 }
 
+func (s InvalidRequest) GetType__() bindings.BindingType {
+	return InvalidRequestBindingType()
+}
+
+func (s InvalidRequest) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for InvalidRequest._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
+
 // The ``NotAllowedInCurrentState`` exception indicates that the requested method is not allowed with a resource or service in its current state. This could be because the method is performing a configuration change that is not allowed in the current state or because method itself is not allowed in the current state. 
 //
 //  Examples: 
@@ -537,6 +759,23 @@ func (NotAllowedInCurrentState NotAllowedInCurrentState) Error() string {
 	return "com.vmware.vapi.std.errors.not_allowed_in_current_state"
 }
 
+func (s NotAllowedInCurrentState) GetType__() bindings.BindingType {
+	return NotAllowedInCurrentStateBindingType()
+}
+
+func (s NotAllowedInCurrentState) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for NotAllowedInCurrentState._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
+
 // The ``NotFound`` exception indicates that a specified element could not be found. 
 //
 //  Examples: 
@@ -565,6 +804,23 @@ func NewNotFound() *NotFound {
 func (NotFound NotFound) Error() string {
 	return "com.vmware.vapi.std.errors.not_found"
 }
+
+func (s NotFound) GetType__() bindings.BindingType {
+	return NotFoundBindingType()
+}
+
+func (s NotFound) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for NotFound._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``OperationNotFound`` exception indicates that the method specified in the request could not be found. 
 //
@@ -604,6 +860,23 @@ func (OperationNotFound OperationNotFound) Error() string {
 	return "com.vmware.vapi.std.errors.operation_not_found"
 }
 
+func (s OperationNotFound) GetType__() bindings.BindingType {
+	return OperationNotFoundBindingType()
+}
+
+func (s OperationNotFound) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for OperationNotFound._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
+
 // The ``ResourceBusy`` exception indicates that the method could not be completed because a resource it needs is busy. 
 //
 //  Examples: 
@@ -636,6 +909,23 @@ func NewResourceBusy() *ResourceBusy {
 func (ResourceBusy ResourceBusy) Error() string {
 	return "com.vmware.vapi.std.errors.resource_busy"
 }
+
+func (s ResourceBusy) GetType__() bindings.BindingType {
+	return ResourceBusyBindingType()
+}
+
+func (s ResourceBusy) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for ResourceBusy._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``ResourceInUse`` exception indicates that the method could not be completed because a resource is in use. 
 //
@@ -670,6 +960,23 @@ func NewResourceInUse() *ResourceInUse {
 func (ResourceInUse ResourceInUse) Error() string {
 	return "com.vmware.vapi.std.errors.resource_in_use"
 }
+
+func (s ResourceInUse) GetType__() bindings.BindingType {
+	return ResourceInUseBindingType()
+}
+
+func (s ResourceInUse) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for ResourceInUse._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``ResourceInaccessible`` exception indicates that the method could not be completed because an entity is not accessible. 
 //
@@ -706,6 +1013,23 @@ func (ResourceInaccessible ResourceInaccessible) Error() string {
 	return "com.vmware.vapi.std.errors.resource_inaccessible"
 }
 
+func (s ResourceInaccessible) GetType__() bindings.BindingType {
+	return ResourceInaccessibleBindingType()
+}
+
+func (s ResourceInaccessible) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for ResourceInaccessible._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
+
 // The ``ServiceUnavailable`` exception indicates that the interface is unavailable. 
 //
 //  Examples: 
@@ -741,6 +1065,23 @@ func NewServiceUnavailable() *ServiceUnavailable {
 func (ServiceUnavailable ServiceUnavailable) Error() string {
 	return "com.vmware.vapi.std.errors.service_unavailable"
 }
+
+func (s ServiceUnavailable) GetType__() bindings.BindingType {
+	return ServiceUnavailableBindingType()
+}
+
+func (s ServiceUnavailable) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for ServiceUnavailable._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``TimedOut`` exception indicates that the method did not complete within the allowed amount of time. The allowed amount of time might be: 
 //
@@ -782,6 +1123,23 @@ func (TimedOut TimedOut) Error() string {
 	return "com.vmware.vapi.std.errors.timed_out"
 }
 
+func (s TimedOut) GetType__() bindings.BindingType {
+	return TimedOutBindingType()
+}
+
+func (s TimedOut) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for TimedOut._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
+
 // The ``TransientIndication`` class indicates whether or not the exception is transient. 
 //
 //  Some types of exceptions are transient in certain situtations and not transient in other situtations. This exception payload can be used to indicate to clients whether a particular exception is transient. See Error#data.
@@ -789,6 +1147,23 @@ type TransientIndication struct {
     // Indicates that the exception this class is attached to is transient.
 	IsTransient bool
 }
+
+func (s TransientIndication) GetType__() bindings.BindingType {
+	return TransientIndicationBindingType()
+}
+
+func (s TransientIndication) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for TransientIndication._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``UnableToAllocateResource`` exception indicates that the method failed because it was unable to allocate or acquire a required resource. 
 //
@@ -826,6 +1201,23 @@ func NewUnableToAllocateResource() *UnableToAllocateResource {
 func (UnableToAllocateResource UnableToAllocateResource) Error() string {
 	return "com.vmware.vapi.std.errors.unable_to_allocate_resource"
 }
+
+func (s UnableToAllocateResource) GetType__() bindings.BindingType {
+	return UnableToAllocateResourceBindingType()
+}
+
+func (s UnableToAllocateResource) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for UnableToAllocateResource._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``Unauthenticated`` exception indicates that the method requires authentication and the user is not authenticated. 
 //
@@ -869,6 +1261,23 @@ func NewUnauthenticated() *Unauthenticated {
 func (Unauthenticated Unauthenticated) Error() string {
 	return "com.vmware.vapi.std.errors.unauthenticated"
 }
+
+func (s Unauthenticated) GetType__() bindings.BindingType {
+	return UnauthenticatedBindingType()
+}
+
+func (s Unauthenticated) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for Unauthenticated._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``Unauthorized`` exception indicates that the user is not authorized to perform the method. 
 //
@@ -914,6 +1323,23 @@ func (Unauthorized Unauthorized) Error() string {
 	return "com.vmware.vapi.std.errors.unauthorized"
 }
 
+func (s Unauthorized) GetType__() bindings.BindingType {
+	return UnauthorizedBindingType()
+}
+
+func (s Unauthorized) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for Unauthorized._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
+
 // The ``UnexpectedInput`` exception indicates that the request contained a parameter or property whose name is not known by the server. 
 //
 //  Every method expects parameters with known names. Some of those parameters may be (or contain) classes, and the method expects those classes to contain properties with known names. If the method receives parameters or properties with names that is does not expect, this exception may be reported. 
@@ -946,6 +1372,23 @@ func (UnexpectedInput UnexpectedInput) Error() string {
 	return "com.vmware.vapi.std.errors.unexpected_input"
 }
 
+func (s UnexpectedInput) GetType__() bindings.BindingType {
+	return UnexpectedInputBindingType()
+}
+
+func (s UnexpectedInput) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for UnexpectedInput._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
+
 // The ``Unsupported`` exception indicates that the method is not supported by the interface. 
 //
 //  Examples: 
@@ -973,6 +1416,23 @@ func NewUnsupported() *Unsupported {
 func (Unsupported Unsupported) Error() string {
 	return "com.vmware.vapi.std.errors.unsupported"
 }
+
+func (s Unsupported) GetType__() bindings.BindingType {
+	return UnsupportedBindingType()
+}
+
+func (s Unsupported) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for Unsupported._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 // The ``UnverifiedPeer`` exception indicates that an attempt to connect to an unknown or not-yet-trusted endpoint failed because the system was unable to verify the identity of the endpoint. 
 //
@@ -1005,6 +1465,23 @@ func NewUnverifiedPeer() *UnverifiedPeer {
 func (UnverifiedPeer UnverifiedPeer) Error() string {
 	return "com.vmware.vapi.std.errors.unverified_peer"
 }
+
+func (s UnverifiedPeer) GetType__() bindings.BindingType {
+	return UnverifiedPeerBindingType()
+}
+
+func (s UnverifiedPeer) GetDataValue__() (data.DataValue, []error) {
+	typeConverter := bindings.NewTypeConverter()
+	typeConverter.SetMode(bindings.JSONRPC)
+	dataVal, err := typeConverter.ConvertToVapi(s, s.GetType__())
+	if err != nil {
+		log.Errorf("Error in ConvertToVapi for UnverifiedPeer._GetDataValue method - %s",
+			bindings.VAPIerrorsToError(err).Error())
+		return nil, err
+	}
+	return dataVal, nil
+}
+
 
 
 

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/bindings/ErrorUtil.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/bindings/ErrorUtil.go
@@ -1,14 +1,15 @@
-/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+/* Copyright © 2019-2020 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: BSD-2-Clause */
 
 package bindings
 
 import (
+	"reflect"
+	"time"
+
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/data"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/l10n"
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/log"
-	"reflect"
-	"time"
 )
 
 //localizable message fields

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/bindings/Structure.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/bindings/Structure.go
@@ -1,0 +1,12 @@
+/* Copyright © 2020 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: BSD-2-Clause */
+
+package bindings
+
+import "github.com/vmware/vsphere-automation-sdk-go/runtime/data"
+
+// Structure Base interface that represents a Go language bindings structure.
+type Structure interface {
+	GetType__() BindingType
+	GetDataValue__() (data.DataValue, []error)
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/data/ErrorValue.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/data/ErrorValue.go
@@ -3,48 +3,20 @@
 
 package data
 
-import "errors"
-
 /**
  * <code>DataValue</code> implementation for vAPI errors.
  */
 type ErrorValue struct {
-	name   string
-	fields map[string]DataValue
+	StructValue
 }
 
 func NewErrorValue(name string, fields map[string]DataValue) *ErrorValue {
 	if fields == nil {
-		return &ErrorValue{name: name, fields: make(map[string]DataValue)}
+		return &ErrorValue{StructValue{name: name, fields: make(map[string]DataValue)}}
 	}
-	return &ErrorValue{name: name, fields: fields}
+	return &ErrorValue{StructValue{name: name, fields: fields}}
 }
 
 func (errorValue *ErrorValue) Type() DataType {
 	return ERROR
-}
-
-func (errorValue *ErrorValue) Name() string {
-	return errorValue.name
-}
-
-func (errorValue *ErrorValue) SetField(field string, value DataValue) {
-	errorValue.fields[field] = value
-}
-
-func (errorValue *ErrorValue) Field(field string) (DataValue, error) {
-	if dataValue, ok := errorValue.fields[field]; ok {
-		return dataValue, nil
-	}
-	return nil, errors.New("vapi.data.error.getfield.unknown" + field)
-}
-func (errorValue *ErrorValue) Fields() map[string]DataValue {
-	return errorValue.fields
-}
-
-func (errorValue *ErrorValue) HasField(field string) bool {
-	if _, ok := errorValue.fields[field]; ok {
-		return true
-	}
-	return false
 }

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/data/serializers/rest/RequestSerializer.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/data/serializers/rest/RequestSerializer.go
@@ -64,7 +64,7 @@ func (result *Request) SetRequestBody(body string) {
 	result.requestBody = body
 }
 
-// Deprecated: Use SerializeRequestsWithSecCtxSerializers() instead.
+// SerializeRequests Deprecated: Use SerializeRequestsWithSecCtxSerializers() instead.
 // SerializeRequests serializes a request as a REST request
 // Return Request with urlPath, inputHeaders and requestBody
 func SerializeRequests(inputValue *data.StructValue, ctx *core.ExecutionContext,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/data/serializers/rest/SecurityContextSerializer.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/data/serializers/rest/SecurityContextSerializer.go
@@ -4,8 +4,8 @@
 package rest
 
 import (
-	"errors"
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	"github.com/vmware/vsphere-automation-sdk-go/runtime/core"
@@ -78,7 +78,7 @@ func NewOauthSecContextSerializer() *OauthSecContextSerializer {
 	return &OauthSecContextSerializer{}
 }
 
-//  Serialize authorization headers for oauth security context.
+// Serialize authorization headers for oauth security context.
 func (o *OauthSecContextSerializer) Serialize(ctx core.SecurityContext) (map[string]interface{}, error) {
 	oauthToken, err := GetSecurityCtxStrValue(ctx, security.ACCESS_TOKEN)
 	if err != nil {

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/l10n/runtime/runtimeproperties_en.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/l10n/runtime/runtimeproperties_en.go
@@ -1,4 +1,4 @@
-/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+/* Copyright © 2019-2020 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: BSD-2-Clause */
 
 package runtime
@@ -72,6 +72,8 @@ vapi.security.authentication.certificate.invalid=Unable to verify server certifi
 
 vapi.security.authorization.exception=Exception in invoking authorization handler {msg}
 vapi.security.authorization.invalid=Unable to authorize user
+vapi.security.authorization.invalid_with_error=Unable to authorize user. Error occured: {err}
+vapi.security.authorization.internal_server_error=Internal server error occured on authorization: {err}
 
 vapi.security.sso.digest.invalid=Invalid digest.
 vapi.security.sso.hash.invalid=Invalid hash algorithm.
@@ -80,6 +82,8 @@ vapi.security.sso.pvtkey.invalid=Invalid private key.
 vapi.security.sso.samltoken.invalid=Invalid saml token.
 vapi.security.sso.signature.invalid=Invalid signature.
 vapi.security.sso.signature.algorithm.invalid=Invalid signature algorithm.
+
+vapi.protocol.server.error=Server error occured: {err}
 
 vapi.protocol.server.rest.param.invalid_value=Parsing failed because of '{errMsg}'
 vapi.protocol.server.rest.param.invalid_type=Invalid value for request parameter '{paramName}'. Expected a value of type '{expectedType}', but parsing failed because of '{errMsg}'
@@ -96,6 +100,8 @@ vapi.protocol.server.rest.param.body.unexpected=Request body data type expected 
 vapi.protocol.server.rest.param.internal_server_error= Request process params failure: {msg}
 vapi.protocol.server.rest.response.unsupport_type=Response data type '{dataType}' not supported for field '{fieldName}'
 vapi.protocol.server.rest.response.not_structure=Response result is not a structure type
+vapi.protocol.server.rest.response.not_error=Response result is not an error type
+vapi.protocol.server.rest.response.invalid=Response result is nil
 vapi.protocol.server.rest.response.error_not_structure=Response error is not a structure type
 vapi.protocol.server.rest.response.result_failed=Method execution failed, do not set response header
 vapi.protocol.server.rest.response.unsupport_http_status=Http status '{httpStatus}' not supported

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client/metadata/version.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client/metadata/version.go
@@ -1,3 +1,3 @@
 package metadata
 
-const RuntimeVersion = "0.2.0"
+const RuntimeVersion = "0.3.1"

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/server/Server.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/server/Server.go
@@ -1,0 +1,96 @@
+/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: BSD-2-Clause */
+
+package server
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/l10n"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/log"
+	"golang.org/x/net/context"
+)
+
+// Server Wraps http server and provides basic functionality
+// such as server start and stop
+type Server struct {
+	srv *http.Server
+}
+
+// NewServer returns Server object
+func NewServer(portnumber string, handler http.Handler) *Server {
+	return &Server{srv: &http.Server{Addr: portnumber, Handler: handler}}
+}
+
+// Start Starts http server
+func (s *Server) Start() chan error {
+	errorChannel := make(chan error)
+	go func() {
+		// catch when server panics
+		defer func() {
+			if r := recover(); r != nil {
+				err, ok := r.(error)
+				var errorMsg string
+				if ok {
+					errorMsg = err.Error()
+				} else {
+					errorMsg = fmt.Sprintf("Server error occured: %#v", r)
+				}
+
+				errorChannel <- l10n.NewRuntimeError(
+					"vapi.protocol.server.error",
+					map[string]string{"err": errorMsg})
+			}
+		}()
+		if err := s.srv.ListenAndServe(); err != nil {
+			errorChannel <- l10n.NewRuntimeError(
+				"vapi.protocol.server.error",
+				map[string]string{"err": err.Error()})
+		}
+	}()
+
+	log.Infof("HTTP Server starting on %s", s.srv.Addr)
+	return errorChannel
+}
+
+// WaitForRunningPort waits until a server port gets used by the OS.
+// Should be used after call to Start method. Returned error channel from Start
+// method is expected as input parameter.
+// Closes server in case of error.
+func (s *Server) WaitForRunningPort(errChannel chan error, seconds int) (bool, error) {
+	check, err := WaitForFunc(seconds, func() (bool, error) {
+		select {
+		case err := <-errChannel:
+			return false, err
+		default:
+			_, err := net.Dial("tcp", s.Address())
+			if err == nil {
+				return true, nil
+			}
+			return false, nil
+		}
+	})
+	if err != nil || !check {
+		s.Stop()
+		return false, err
+	}
+
+	log.Info("Server started successfully on ", s.Address())
+	return true, nil
+}
+
+// Stop Stops http server gracefully
+func (s *Server) Stop() {
+	log.Info("Stopping Http Server")
+	if err := s.srv.Shutdown(context.TODO()); err != nil {
+		panic(err) // failure/timeout shutting down the server gracefully
+	}
+	log.Infof("Server at %s stopped.", s.srv.Addr)
+}
+
+// Address Returns server address
+func (s *Server) Address() string {
+	return s.srv.Addr
+}

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/types.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/types.go
@@ -94,7 +94,7 @@ type OperationRestMetadata struct {
 	// Map from result field name to http header name
 	resultHeadersNameMap map[string]string
 	// Map from error field name to http header name
-	errorHeadersNameMap map[string]string
+	errorHeadersNameMap map[string]map[string]string
 }
 
 func NewOperationRestMetadata(
@@ -114,7 +114,7 @@ func NewOperationRestMetadata(
 	resultHeadersNameMap map[string]string,
 	successCode int,
 	responseBodyName string,
-	errorHeadersNameMap map[string]string,
+	errorHeadersNameMap map[string]map[string]string,
 	errorCodeMap map[string]int) OperationRestMetadata {
 
 	return OperationRestMetadata{
@@ -205,7 +205,7 @@ func (meta OperationRestMetadata) ErrorCodeMap() map[string]int {
 func (meta OperationRestMetadata) ResultHeadersNameMap() map[string]string {
 	return meta.resultHeadersNameMap
 }
-func (meta OperationRestMetadata) ErrorHeadersNameMap() map[string]string {
+func (meta OperationRestMetadata) ErrorHeadersNameMap() map[string]map[string]string {
 	return meta.errorHeadersNameMap
 }
 

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/security/AuthorizationFilter.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/security/AuthorizationFilter.go
@@ -1,4 +1,4 @@
-/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+/* Copyright © 2019-2020 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: BSD-2-Clause */
 
 package security
@@ -46,19 +46,20 @@ func (a *AuthorizationFilter) Invoke(serviceID string, operationID string,
 
 	requiredPrivileges, err := a.privilegeProv.GetPrivilegeInfo(fullyQualifiedOperName, inputValue)
 	if err != nil {
-		return a.getInvalidAuthzMethodResult(nil)
+		return a.getInvalidAuthzMethodResult(err)
 	}
 
-	if !a.pValidator.Validate(userName, groupNames, requiredPrivileges) {
-		return a.getInvalidAuthzMethodResult(nil)
+	isValid, err := a.pValidator.Validate(userName, groupNames, requiredPrivileges)
+	if !isValid || err != nil {
+		return a.getInvalidAuthzMethodResult(err)
 	}
 
 	for _, authzHandler := range a.handlers {
 		//TODO invoke only those handlers which support auth schemes.
-		authzResult, authzError := authzHandler.Authorize(serviceID, operationID, ctx.SecurityContext())
-		if authzError != nil {
+		authzResult, err := authzHandler.Authorize(serviceID, operationID, ctx.SecurityContext())
+		if err != nil {
 			// authz failed.
-			return a.getInvalidAuthzMethodResult(authzError)
+			return a.getInvalidAuthzMethodResult(err)
 		} else if authzResult {
 			return a.provider.Invoke(serviceID, operationID, inputValue, ctx)
 		}
@@ -66,14 +67,26 @@ func (a *AuthorizationFilter) Invoke(serviceID string, operationID string,
 	return a.getInvalidAuthzMethodResult(nil)
 }
 
-func (a *AuthorizationFilter) getInvalidAuthzMethodResult(authzError error) core.MethodResult {
-	if authzError != nil {
-		errorValue := bindings.CreateErrorValueFromMessageId(bindings.UNAUTHORIZED_ERROR_DEF,
-			"vapi.security.authorization.invalid", nil)
+func (a *AuthorizationFilter) getInvalidAuthzMethodResult(err error) core.MethodResult {
+	var errorValue *data.ErrorValue
+	if err != nil {
+		if vapiError, isVapiError := err.(bindings.Structure); isVapiError {
+			dataVal, err := vapiError.GetDataValue__()
+			if dataVal != nil && err == nil {
+				errorValue = dataVal.(*data.ErrorValue)
+			}
+		}
+
+		if errorValue == nil {
+			args := map[string]string{"err": err.Error()}
+			errorValue = bindings.CreateErrorValueFromMessageId(bindings.INTERNAL_SERVER_ERROR_DEF,
+				"vapi.security.authorization.internal_server_error", args)
+		}
 
 		return core.NewMethodResult(nil, errorValue)
 	}
-	errorValue := bindings.CreateErrorValueFromMessageId(bindings.UNAUTHORIZED_ERROR_DEF,
+
+	errorValue = bindings.CreateErrorValueFromMessageId(bindings.UNAUTHORIZED_ERROR_DEF,
 		"vapi.security.authorization.invalid", nil)
 
 	return core.NewMethodResult(nil, errorValue)

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/security/PermissionValidator.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/security/PermissionValidator.go
@@ -1,9 +1,8 @@
-/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+/* Copyright © 2019-2020 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: BSD-2-Clause */
 
 package security
 
-
 type PermissionValidator interface {
-	Validate(username string, groups []string, requiredPrivileges map[ResourceIdentifier][]string) bool
+	Validate(username string, groups []string, requiredPrivileges map[ResourceIdentifier][]string) (bool, error)
 }

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/security/constants.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/security/constants.go
@@ -1,4 +1,4 @@
-/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+/* Copyright © 2019-2020 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: BSD-2-Clause */
 
 package security
@@ -37,3 +37,6 @@ const ACCESS_TOKEN = "accessToken"
 const RS256 = "RS256"
 const RS384 = "RS384"
 const RS512 = "RS512"
+
+const TS_EXPIRES_KEY = "expires"
+const TS_CREATED_KEY = "created"

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/security/util.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/runtime/security/util.go
@@ -1,4 +1,4 @@
-/* Copyright © 2019 VMware, Inc. All Rights Reserved.
+/* Copyright © 2019-2020 VMware, Inc. All Rights Reserved.
    SPDX-License-Identifier: BSD-2-Clause */
 
 package security
@@ -11,12 +11,14 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/beevik/etree"
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/lib"
-	"github.com/vmware/vsphere-automation-sdk-go/runtime/log"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/beevik/etree"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/bindings"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/lib"
+	"github.com/vmware/vsphere-automation-sdk-go/runtime/log"
 )
 
 // Extracts Security Context from request.
@@ -109,7 +111,8 @@ func PrepareCertificate(certString string) string {
 func GenerateRequestTimeStamp() map[string]string {
 	createdDate := time.Now().UTC()
 	expires := createdDate.Add(time.Minute * REQUEST_VALIDITY)
-	return map[string]string{"EXPIRES": expires.String(), "CREATED": createdDate.String()}
+	return map[string]string{TS_EXPIRES_KEY: expires.Format(bindings.VAPI_DATETIME_LAYOUT),
+		TS_CREATED_KEY: createdDate.Format(bindings.VAPI_DATETIME_LAYOUT)}
 }
 
 // Verify signature of sig by generating signature using public key with toVerify

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/BfdProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/BfdProfilesTypes.go
@@ -52,7 +52,7 @@ func bfdProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["bfdProfileId"] = bindings.NewStringType()
 	pathParams["bfd_profile_id"] = "bfdProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func bfdProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["bfdProfileId"] = bindings.NewStringType()
 	pathParams["bfd_profile_id"] = "bfdProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func bfdProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func bfdProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["bfdProfileId"] = bindings.NewStringType()
 	pathParams["bfd_profile_id"] = "bfdProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func bfdProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["bfdProfileId"] = bindings.NewStringType()
 	pathParams["bfd_profile_id"] = "bfdProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/CertificatesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/CertificatesTypes.go
@@ -54,7 +54,7 @@ func certificatesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["certificateId"] = bindings.NewStringType()
 	pathParams["certificate_id"] = "certificateId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -110,7 +110,7 @@ func certificatesGetRestMetadata() protocol.OperationRestMetadata {
 	pathParams["certificate_id"] = "certificateId"
 	queryParams["details"] = "details"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -195,7 +195,7 @@ func certificatesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["type"] = "type"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -250,7 +250,7 @@ func certificatesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["certificateId"] = bindings.NewStringType()
 	pathParams["certificate_id"] = "certificateId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -305,7 +305,7 @@ func certificatesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["certificateId"] = bindings.NewStringType()
 	pathParams["certificate_id"] = "certificateId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ConstraintsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ConstraintsTypes.go
@@ -52,7 +52,7 @@ func constraintsDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["constraintId"] = bindings.NewStringType()
 	pathParams["constraint_id"] = "constraintId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func constraintsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["constraintId"] = bindings.NewStringType()
 	pathParams["constraint_id"] = "constraintId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func constraintsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func constraintsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["constraintId"] = bindings.NewStringType()
 	pathParams["constraint_id"] = "constraintId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func constraintsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["constraintId"] = bindings.NewStringType()
 	pathParams["constraint_id"] = "constraintId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ContextProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ContextProfilesTypes.go
@@ -58,7 +58,7 @@ func contextProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["context_profile_id"] = "contextProfileId"
 	queryParams["force"] = "force"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -108,7 +108,7 @@ func contextProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["contextProfileId"] = bindings.NewStringType()
 	pathParams["context_profile_id"] = "contextProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func contextProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func contextProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["contextProfileId"] = bindings.NewStringType()
 	pathParams["context_profile_id"] = "contextProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func contextProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["contextProfileId"] = bindings.NewStringType()
 	pathParams["context_profile_id"] = "contextProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/CrlsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/CrlsTypes.go
@@ -54,7 +54,7 @@ func crlsDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["crlId"] = bindings.NewStringType()
 	pathParams["crl_id"] = "crlId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -110,7 +110,7 @@ func crlsGetRestMetadata() protocol.OperationRestMetadata {
 	pathParams["crl_id"] = "crlId"
 	queryParams["details"] = "details"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -165,7 +165,7 @@ func crlsImportcrlRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["crlId"] = bindings.NewStringType()
 	pathParams["crl_id"] = "crlId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -250,7 +250,7 @@ func crlsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["type"] = "type"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -305,7 +305,7 @@ func crlsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["crlId"] = bindings.NewStringType()
 	pathParams["crl_id"] = "crlId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -360,7 +360,7 @@ func crlsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["crlId"] = bindings.NewStringType()
 	pathParams["crl_id"] = "crlId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DeploymentZonesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DeploymentZonesTypes.go
@@ -52,7 +52,7 @@ func deploymentZonesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["deploymentZoneId"] = bindings.NewStringType()
 	pathParams["deployment_zone_id"] = "deploymentZoneId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -131,7 +131,7 @@ func deploymentZonesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DhcpRelayConfigsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DhcpRelayConfigsTypes.go
@@ -52,7 +52,7 @@ func dhcpRelayConfigsDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dhcpRelayConfigId"] = bindings.NewStringType()
 	pathParams["dhcp_relay_config_id"] = "dhcpRelayConfigId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func dhcpRelayConfigsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dhcpRelayConfigId"] = bindings.NewStringType()
 	pathParams["dhcp_relay_config_id"] = "dhcpRelayConfigId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func dhcpRelayConfigsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func dhcpRelayConfigsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dhcpRelayConfigId"] = bindings.NewStringType()
 	pathParams["dhcp_relay_config_id"] = "dhcpRelayConfigId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func dhcpRelayConfigsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dhcpRelayConfigId"] = bindings.NewStringType()
 	pathParams["dhcp_relay_config_id"] = "dhcpRelayConfigId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DhcpServerConfigsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DhcpServerConfigsTypes.go
@@ -52,7 +52,7 @@ func dhcpServerConfigsDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dhcpServerConfigId"] = bindings.NewStringType()
 	pathParams["dhcp_server_config_id"] = "dhcpServerConfigId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func dhcpServerConfigsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dhcpServerConfigId"] = bindings.NewStringType()
 	pathParams["dhcp_server_config_id"] = "dhcpServerConfigId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func dhcpServerConfigsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func dhcpServerConfigsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dhcpServerConfigId"] = bindings.NewStringType()
 	pathParams["dhcp_server_config_id"] = "dhcpServerConfigId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func dhcpServerConfigsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dhcpServerConfigId"] = bindings.NewStringType()
 	pathParams["dhcp_server_config_id"] = "dhcpServerConfigId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DnsForwarderZonesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DnsForwarderZonesTypes.go
@@ -52,7 +52,7 @@ func dnsForwarderZonesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dnsForwarderZoneId"] = bindings.NewStringType()
 	pathParams["dns_forwarder_zone_id"] = "dnsForwarderZoneId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func dnsForwarderZonesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dnsForwarderZoneId"] = bindings.NewStringType()
 	pathParams["dns_forwarder_zone_id"] = "dnsForwarderZoneId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func dnsForwarderZonesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func dnsForwarderZonesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dnsForwarderZoneId"] = bindings.NewStringType()
 	pathParams["dns_forwarder_zone_id"] = "dnsForwarderZoneId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func dnsForwarderZonesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dnsForwarderZoneId"] = bindings.NewStringType()
 	pathParams["dns_forwarder_zone_id"] = "dnsForwarderZoneId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DnsSecurityProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DnsSecurityProfilesTypes.go
@@ -52,7 +52,7 @@ func dnsSecurityProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["profileId"] = bindings.NewStringType()
 	pathParams["profile_id"] = "profileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func dnsSecurityProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["profileId"] = bindings.NewStringType()
 	pathParams["profile_id"] = "profileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func dnsSecurityProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func dnsSecurityProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["profileId"] = bindings.NewStringType()
 	pathParams["profile_id"] = "profileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func dnsSecurityProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["profileId"] = bindings.NewStringType()
 	pathParams["profile_id"] = "profileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DomainsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DomainsTypes.go
@@ -52,7 +52,7 @@ func domainsDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["domainId"] = bindings.NewStringType()
 	pathParams["domain_id"] = "domainId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func domainsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["domainId"] = bindings.NewStringType()
 	pathParams["domain_id"] = "domainId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func domainsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func domainsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["domainId"] = bindings.NewStringType()
 	pathParams["domain_id"] = "domainId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func domainsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["domainId"] = bindings.NewStringType()
 	pathParams["domain_id"] = "domainId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DraftsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/DraftsTypes.go
@@ -52,7 +52,7 @@ func draftsDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["draftId"] = bindings.NewStringType()
 	pathParams["draft_id"] = "draftId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func draftsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["draftId"] = bindings.NewStringType()
 	pathParams["draft_id"] = "draftId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func draftsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func draftsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["draftId"] = bindings.NewStringType()
 	pathParams["draft_id"] = "draftId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func draftsPublishRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["draftId"] = bindings.NewStringType()
 	pathParams["draft_id"] = "draftId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -352,7 +352,7 @@ func draftsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["draftId"] = bindings.NewStringType()
 	pathParams["draft_id"] = "draftId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/FederationConfigTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/FederationConfigTypes.go
@@ -45,7 +45,7 @@ func federationConfigGetRestMetadata() protocol.OperationRestMetadata {
 	dispatchHeaderParams := map[string]string{}
 	bodyFieldsMap := map[string]string{}
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/FirewallSchedulersTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/FirewallSchedulersTypes.go
@@ -58,7 +58,7 @@ func firewallSchedulersDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["firewall_scheduler_id"] = "firewallSchedulerId"
 	queryParams["force"] = "force"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -108,7 +108,7 @@ func firewallSchedulersGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["firewallSchedulerId"] = bindings.NewStringType()
 	pathParams["firewall_scheduler_id"] = "firewallSchedulerId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func firewallSchedulersListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func firewallSchedulersPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["firewallSchedulerId"] = bindings.NewStringType()
 	pathParams["firewall_scheduler_id"] = "firewallSchedulerId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func firewallSchedulersUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["firewallSchedulerId"] = bindings.NewStringType()
 	pathParams["firewall_scheduler_id"] = "firewallSchedulerId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/FirewallSessionTimerProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/FirewallSessionTimerProfilesTypes.go
@@ -52,7 +52,7 @@ func firewallSessionTimerProfilesDeleteRestMetadata() protocol.OperationRestMeta
 	paramsTypeMap["firewallSessionTimerProfileId"] = bindings.NewStringType()
 	pathParams["firewall_session_timer_profile_id"] = "firewallSessionTimerProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func firewallSessionTimerProfilesGetRestMetadata() protocol.OperationRestMetadat
 	paramsTypeMap["firewallSessionTimerProfileId"] = bindings.NewStringType()
 	pathParams["firewall_session_timer_profile_id"] = "firewallSessionTimerProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func firewallSessionTimerProfilesListRestMetadata() protocol.OperationRestMetada
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func firewallSessionTimerProfilesPatchRestMetadata() protocol.OperationRestMetad
 	paramsTypeMap["firewallSessionTimerProfileId"] = bindings.NewStringType()
 	pathParams["firewall_session_timer_profile_id"] = "firewallSessionTimerProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func firewallSessionTimerProfilesUpdateRestMetadata() protocol.OperationRestMeta
 	paramsTypeMap["firewallSessionTimerProfileId"] = bindings.NewStringType()
 	pathParams["firewall_session_timer_profile_id"] = "firewallSessionTimerProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/FloodProtectionProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/FloodProtectionProfilesTypes.go
@@ -52,7 +52,7 @@ func floodProtectionProfilesDeleteRestMetadata() protocol.OperationRestMetadata 
 	paramsTypeMap["floodProtectionProfileId"] = bindings.NewStringType()
 	pathParams["flood_protection_profile_id"] = "floodProtectionProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func floodProtectionProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["floodProtectionProfileId"] = bindings.NewStringType()
 	pathParams["flood_protection_profile_id"] = "floodProtectionProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func floodProtectionProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func floodProtectionProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["floodProtectionProfileId"] = bindings.NewStringType()
 	pathParams["flood_protection_profile_id"] = "floodProtectionProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func floodProtectionProfilesUpdateRestMetadata() protocol.OperationRestMetadata 
 	paramsTypeMap["floodProtectionProfileId"] = bindings.NewStringType()
 	pathParams["flood_protection_profile_id"] = "floodProtectionProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/FullSyncStatesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/FullSyncStatesTypes.go
@@ -52,7 +52,7 @@ func fullSyncStatesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["fullSyncId"] = bindings.NewStringType()
 	pathParams["full_sync_id"] = "fullSyncId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -131,7 +131,7 @@ func fullSyncStatesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/GatewayQosProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/GatewayQosProfilesTypes.go
@@ -52,7 +52,7 @@ func gatewayQosProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["qosProfileId"] = bindings.NewStringType()
 	pathParams["qos_profile_id"] = "qosProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func gatewayQosProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["qosProfileId"] = bindings.NewStringType()
 	pathParams["qos_profile_id"] = "qosProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func gatewayQosProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func gatewayQosProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["qosProfileId"] = bindings.NewStringType()
 	pathParams["qos_profile_id"] = "qosProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func gatewayQosProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["qosProfileId"] = bindings.NewStringType()
 	pathParams["qos_profile_id"] = "qosProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/GlobalConfigTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/GlobalConfigTypes.go
@@ -45,7 +45,7 @@ func globalConfigGetRestMetadata() protocol.OperationRestMetadata {
 	dispatchHeaderParams := map[string]string{}
 	bodyFieldsMap := map[string]string{}
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -93,7 +93,7 @@ func globalConfigPatchRestMetadata() protocol.OperationRestMetadata {
 	fieldNameMap["global_config"] = "GlobalConfig"
 	paramsTypeMap["global_config"] = bindings.NewReferenceType(model.GlobalConfigBindingType)
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -141,7 +141,7 @@ func globalConfigUpdateRestMetadata() protocol.OperationRestMetadata {
 	fieldNameMap["global_config"] = "GlobalConfig"
 	paramsTypeMap["global_config"] = bindings.NewReferenceType(model.GlobalConfigBindingType)
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/GlobalManagerConfigTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/GlobalManagerConfigTypes.go
@@ -50,7 +50,7 @@ func globalManagerConfigPatchRestMetadata() protocol.OperationRestMetadata {
 	fieldNameMap["global_manager_config"] = "GlobalManagerConfig"
 	paramsTypeMap["global_manager_config"] = bindings.NewReferenceType(model.GlobalManagerConfigBindingType)
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -93,7 +93,7 @@ func globalManagerConfigShowsensitivedataRestMetadata() protocol.OperationRestMe
 	dispatchHeaderParams := map[string]string{}
 	bodyFieldsMap := map[string]string{}
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -141,7 +141,7 @@ func globalManagerConfigUpdateRestMetadata() protocol.OperationRestMetadata {
 	fieldNameMap["global_manager_config"] = "GlobalManagerConfig"
 	paramsTypeMap["global_manager_config"] = bindings.NewReferenceType(model.GlobalManagerConfigBindingType)
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/GlobalManagersTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/GlobalManagersTypes.go
@@ -55,7 +55,7 @@ func globalManagersCreateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["action"] = bindings.NewStringType()
 	queryParams["action"] = "action"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -105,7 +105,7 @@ func globalManagersDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["globalManagerId"] = bindings.NewStringType()
 	pathParams["global_manager_id"] = "globalManagerId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -155,7 +155,7 @@ func globalManagersGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["globalManagerId"] = bindings.NewStringType()
 	pathParams["global_manager_id"] = "globalManagerId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -234,7 +234,7 @@ func globalManagersListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -289,7 +289,7 @@ func globalManagersPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["globalManagerId"] = bindings.NewStringType()
 	pathParams["global_manager_id"] = "globalManagerId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -344,7 +344,7 @@ func globalManagersUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["globalManagerId"] = bindings.NewStringType()
 	pathParams["global_manager_id"] = "globalManagerId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/GroupAssociationsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/GroupAssociationsTypes.go
@@ -93,7 +93,7 @@ func groupAssociationsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/GroupServiceAssociationsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/GroupServiceAssociationsTypes.go
@@ -87,7 +87,7 @@ func groupServiceAssociationsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IgmpProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IgmpProfilesTypes.go
@@ -52,7 +52,7 @@ func igmpProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["igmpProfileId"] = bindings.NewStringType()
 	pathParams["igmp_profile_id"] = "igmpProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func igmpProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["igmpProfileId"] = bindings.NewStringType()
 	pathParams["igmp_profile_id"] = "igmpProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func igmpProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func igmpProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["igmpProfileId"] = bindings.NewStringType()
 	pathParams["igmp_profile_id"] = "igmpProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func igmpProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["igmpProfileId"] = bindings.NewStringType()
 	pathParams["igmp_profile_id"] = "igmpProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpAddressGroupAssociationsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpAddressGroupAssociationsTypes.go
@@ -93,7 +93,7 @@ func ipAddressGroupAssociationsListRestMetadata() protocol.OperationRestMetadata
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpBlocksTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpBlocksTypes.go
@@ -52,7 +52,7 @@ func ipBlocksDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipBlockId"] = bindings.NewStringType()
 	pathParams["ip_block_id"] = "ipBlockId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func ipBlocksGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipBlockId"] = bindings.NewStringType()
 	pathParams["ip_block_id"] = "ipBlockId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func ipBlocksListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func ipBlocksPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipBlockId"] = bindings.NewStringType()
 	pathParams["ip_block_id"] = "ipBlockId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func ipBlocksUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipBlockId"] = bindings.NewStringType()
 	pathParams["ip_block_id"] = "ipBlockId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpDiscoveryProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpDiscoveryProfilesTypes.go
@@ -52,7 +52,7 @@ func ipDiscoveryProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipDiscoveryProfileId"] = bindings.NewStringType()
 	pathParams["ip_discovery_profile_id"] = "ipDiscoveryProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func ipDiscoveryProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipDiscoveryProfileId"] = bindings.NewStringType()
 	pathParams["ip_discovery_profile_id"] = "ipDiscoveryProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func ipDiscoveryProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func ipDiscoveryProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipDiscoveryProfileId"] = bindings.NewStringType()
 	pathParams["ip_discovery_profile_id"] = "ipDiscoveryProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func ipDiscoveryProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipDiscoveryProfileId"] = bindings.NewStringType()
 	pathParams["ip_discovery_profile_id"] = "ipDiscoveryProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpPoolsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpPoolsTypes.go
@@ -52,7 +52,7 @@ func ipPoolsDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipPoolId"] = bindings.NewStringType()
 	pathParams["ip_pool_id"] = "ipPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func ipPoolsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipPoolId"] = bindings.NewStringType()
 	pathParams["ip_pool_id"] = "ipPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func ipPoolsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func ipPoolsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipPoolId"] = bindings.NewStringType()
 	pathParams["ip_pool_id"] = "ipPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func ipPoolsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipPoolId"] = bindings.NewStringType()
 	pathParams["ip_pool_id"] = "ipPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpfixCollectorProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpfixCollectorProfilesTypes.go
@@ -52,7 +52,7 @@ func ipfixCollectorProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixCollectorProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_collector_profile_id"] = "ipfixCollectorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func ipfixCollectorProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixCollectorProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_collector_profile_id"] = "ipfixCollectorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func ipfixCollectorProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func ipfixCollectorProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixCollectorProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_collector_profile_id"] = "ipfixCollectorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func ipfixCollectorProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixCollectorProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_collector_profile_id"] = "ipfixCollectorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpfixDfwCollectorProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpfixDfwCollectorProfilesTypes.go
@@ -52,7 +52,7 @@ func ipfixDfwCollectorProfilesDeleteRestMetadata() protocol.OperationRestMetadat
 	paramsTypeMap["ipfixDfwCollectorProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_dfw_collector_profile_id"] = "ipfixDfwCollectorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func ipfixDfwCollectorProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixDfwCollectorProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_dfw_collector_profile_id"] = "ipfixDfwCollectorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func ipfixDfwCollectorProfilesListRestMetadata() protocol.OperationRestMetadata 
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func ipfixDfwCollectorProfilesPatchRestMetadata() protocol.OperationRestMetadata
 	paramsTypeMap["ipfixDfwCollectorProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_dfw_collector_profile_id"] = "ipfixDfwCollectorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func ipfixDfwCollectorProfilesUpdateRestMetadata() protocol.OperationRestMetadat
 	paramsTypeMap["ipfixDfwCollectorProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_dfw_collector_profile_id"] = "ipfixDfwCollectorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpfixDfwProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpfixDfwProfilesTypes.go
@@ -52,7 +52,7 @@ func ipfixDfwProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixDfwProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_dfw_profile_id"] = "ipfixDfwProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func ipfixDfwProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixDfwProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_dfw_profile_id"] = "ipfixDfwProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func ipfixDfwProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func ipfixDfwProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixDfwProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_dfw_profile_id"] = "ipfixDfwProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func ipfixDfwProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixDfwProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_dfw_profile_id"] = "ipfixDfwProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpfixL2CollectorProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpfixL2CollectorProfilesTypes.go
@@ -52,7 +52,7 @@ func ipfixL2CollectorProfilesDeleteRestMetadata() protocol.OperationRestMetadata
 	paramsTypeMap["ipfixL2CollectorProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_l2_collector_profile_id"] = "ipfixL2CollectorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func ipfixL2CollectorProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixL2CollectorProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_l2_collector_profile_id"] = "ipfixL2CollectorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func ipfixL2CollectorProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func ipfixL2CollectorProfilesPatchRestMetadata() protocol.OperationRestMetadata 
 	paramsTypeMap["ipfixL2CollectorProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_l2_collector_profile_id"] = "ipfixL2CollectorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func ipfixL2CollectorProfilesUpdateRestMetadata() protocol.OperationRestMetadata
 	paramsTypeMap["ipfixL2CollectorProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_l2_collector_profile_id"] = "ipfixL2CollectorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpfixL2ProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpfixL2ProfilesTypes.go
@@ -52,7 +52,7 @@ func ipfixL2ProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixL2ProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_l2_profile_id"] = "ipfixL2ProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func ipfixL2ProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixL2ProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_l2_profile_id"] = "ipfixL2ProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func ipfixL2ProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func ipfixL2ProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixL2ProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_l2_profile_id"] = "ipfixL2ProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func ipfixL2ProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ipfixL2ProfileId"] = bindings.NewStringType()
 	pathParams["ipfix_l2_profile_id"] = "ipfixL2ProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpsecVpnDpdProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpsecVpnDpdProfilesTypes.go
@@ -52,7 +52,7 @@ func ipsecVpnDpdProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dpdProfileId"] = bindings.NewStringType()
 	pathParams["dpd_profile_id"] = "dpdProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func ipsecVpnDpdProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dpdProfileId"] = bindings.NewStringType()
 	pathParams["dpd_profile_id"] = "dpdProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func ipsecVpnDpdProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func ipsecVpnDpdProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dpdProfileId"] = bindings.NewStringType()
 	pathParams["dpd_profile_id"] = "dpdProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func ipsecVpnDpdProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dpdProfileId"] = bindings.NewStringType()
 	pathParams["dpd_profile_id"] = "dpdProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpsecVpnIkeProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpsecVpnIkeProfilesTypes.go
@@ -52,7 +52,7 @@ func ipsecVpnIkeProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ikeProfileId"] = bindings.NewStringType()
 	pathParams["ike_profile_id"] = "ikeProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func ipsecVpnIkeProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ikeProfileId"] = bindings.NewStringType()
 	pathParams["ike_profile_id"] = "ikeProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func ipsecVpnIkeProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func ipsecVpnIkeProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ikeProfileId"] = bindings.NewStringType()
 	pathParams["ike_profile_id"] = "ikeProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func ipsecVpnIkeProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ikeProfileId"] = bindings.NewStringType()
 	pathParams["ike_profile_id"] = "ikeProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpsecVpnTunnelProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/IpsecVpnTunnelProfilesTypes.go
@@ -52,7 +52,7 @@ func ipsecVpnTunnelProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tunnelProfileId"] = bindings.NewStringType()
 	pathParams["tunnel_profile_id"] = "tunnelProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func ipsecVpnTunnelProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tunnelProfileId"] = bindings.NewStringType()
 	pathParams["tunnel_profile_id"] = "tunnelProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func ipsecVpnTunnelProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func ipsecVpnTunnelProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tunnelProfileId"] = bindings.NewStringType()
 	pathParams["tunnel_profile_id"] = "tunnelProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func ipsecVpnTunnelProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tunnelProfileId"] = bindings.NewStringType()
 	pathParams["tunnel_profile_id"] = "tunnelProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/Ipv6DadProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/Ipv6DadProfilesTypes.go
@@ -52,7 +52,7 @@ func ipv6DadProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dadProfileId"] = bindings.NewStringType()
 	pathParams["dad_profile_id"] = "dadProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func ipv6DadProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dadProfileId"] = bindings.NewStringType()
 	pathParams["dad_profile_id"] = "dadProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func ipv6DadProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func ipv6DadProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dadProfileId"] = bindings.NewStringType()
 	pathParams["dad_profile_id"] = "dadProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func ipv6DadProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["dadProfileId"] = bindings.NewStringType()
 	pathParams["dad_profile_id"] = "dadProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/Ipv6NdraProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/Ipv6NdraProfilesTypes.go
@@ -52,7 +52,7 @@ func ipv6NdraProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ndraProfileId"] = bindings.NewStringType()
 	pathParams["ndra_profile_id"] = "ndraProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func ipv6NdraProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ndraProfileId"] = bindings.NewStringType()
 	pathParams["ndra_profile_id"] = "ndraProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func ipv6NdraProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func ipv6NdraProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ndraProfileId"] = bindings.NewStringType()
 	pathParams["ndra_profile_id"] = "ndraProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func ipv6NdraProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["ndraProfileId"] = bindings.NewStringType()
 	pathParams["ndra_profile_id"] = "ndraProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LabelsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LabelsTypes.go
@@ -52,7 +52,7 @@ func labelsDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["labelId"] = bindings.NewStringType()
 	pathParams["label_id"] = "labelId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func labelsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["labelId"] = bindings.NewStringType()
 	pathParams["label_id"] = "labelId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func labelsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func labelsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["labelId"] = bindings.NewStringType()
 	pathParams["label_id"] = "labelId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func labelsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["labelId"] = bindings.NewStringType()
 	pathParams["label_id"] = "labelId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbAppProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbAppProfilesTypes.go
@@ -58,7 +58,7 @@ func lbAppProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["lb_app_profile_id"] = "lbAppProfileId"
 	queryParams["force"] = "force"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -108,7 +108,7 @@ func lbAppProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbAppProfileId"] = bindings.NewStringType()
 	pathParams["lb_app_profile_id"] = "lbAppProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func lbAppProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func lbAppProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbAppProfileId"] = bindings.NewStringType()
 	pathParams["lb_app_profile_id"] = "lbAppProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func lbAppProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbAppProfileId"] = bindings.NewStringType()
 	pathParams["lb_app_profile_id"] = "lbAppProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbClientSslProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbClientSslProfilesTypes.go
@@ -58,7 +58,7 @@ func lbClientSslProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["lb_client_ssl_profile_id"] = "lbClientSslProfileId"
 	queryParams["force"] = "force"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -108,7 +108,7 @@ func lbClientSslProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbClientSslProfileId"] = bindings.NewStringType()
 	pathParams["lb_client_ssl_profile_id"] = "lbClientSslProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func lbClientSslProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func lbClientSslProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbClientSslProfileId"] = bindings.NewStringType()
 	pathParams["lb_client_ssl_profile_id"] = "lbClientSslProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func lbClientSslProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbClientSslProfileId"] = bindings.NewStringType()
 	pathParams["lb_client_ssl_profile_id"] = "lbClientSslProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbMonitorProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbMonitorProfilesTypes.go
@@ -58,7 +58,7 @@ func lbMonitorProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["lb_monitor_profile_id"] = "lbMonitorProfileId"
 	queryParams["force"] = "force"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -108,7 +108,7 @@ func lbMonitorProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbMonitorProfileId"] = bindings.NewStringType()
 	pathParams["lb_monitor_profile_id"] = "lbMonitorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func lbMonitorProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func lbMonitorProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbMonitorProfileId"] = bindings.NewStringType()
 	pathParams["lb_monitor_profile_id"] = "lbMonitorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func lbMonitorProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbMonitorProfileId"] = bindings.NewStringType()
 	pathParams["lb_monitor_profile_id"] = "lbMonitorProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbNodeUsageSummaryTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbNodeUsageSummaryTypes.go
@@ -57,7 +57,7 @@ func lbNodeUsageSummaryGetRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_usages"] = "include_usages"
 	queryParams["enforcement_point_path"] = "enforcement_point_path"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbNodeUsageTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbNodeUsageTypes.go
@@ -51,7 +51,7 @@ func lbNodeUsageGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["node_path"] = bindings.NewStringType()
 	queryParams["node_path"] = "node_path"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbPersistenceProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbPersistenceProfilesTypes.go
@@ -58,7 +58,7 @@ func lbPersistenceProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["lb_persistence_profile_id"] = "lbPersistenceProfileId"
 	queryParams["force"] = "force"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -108,7 +108,7 @@ func lbPersistenceProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbPersistenceProfileId"] = bindings.NewStringType()
 	pathParams["lb_persistence_profile_id"] = "lbPersistenceProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func lbPersistenceProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func lbPersistenceProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbPersistenceProfileId"] = bindings.NewStringType()
 	pathParams["lb_persistence_profile_id"] = "lbPersistenceProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func lbPersistenceProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbPersistenceProfileId"] = bindings.NewStringType()
 	pathParams["lb_persistence_profile_id"] = "lbPersistenceProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbPoolsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbPoolsTypes.go
@@ -58,7 +58,7 @@ func lbPoolsDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["lb_pool_id"] = "lbPoolId"
 	queryParams["force"] = "force"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -108,7 +108,7 @@ func lbPoolsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbPoolId"] = bindings.NewStringType()
 	pathParams["lb_pool_id"] = "lbPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func lbPoolsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func lbPoolsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbPoolId"] = bindings.NewStringType()
 	pathParams["lb_pool_id"] = "lbPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func lbPoolsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbPoolId"] = bindings.NewStringType()
 	pathParams["lb_pool_id"] = "lbPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbServerSslProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbServerSslProfilesTypes.go
@@ -58,7 +58,7 @@ func lbServerSslProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["lb_server_ssl_profile_id"] = "lbServerSslProfileId"
 	queryParams["force"] = "force"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -108,7 +108,7 @@ func lbServerSslProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbServerSslProfileId"] = bindings.NewStringType()
 	pathParams["lb_server_ssl_profile_id"] = "lbServerSslProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func lbServerSslProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func lbServerSslProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbServerSslProfileId"] = bindings.NewStringType()
 	pathParams["lb_server_ssl_profile_id"] = "lbServerSslProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func lbServerSslProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbServerSslProfileId"] = bindings.NewStringType()
 	pathParams["lb_server_ssl_profile_id"] = "lbServerSslProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbServiceUsageSummaryTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbServiceUsageSummaryTypes.go
@@ -51,7 +51,7 @@ func lbServiceUsageSummaryGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["include_usages"] = bindings.NewOptionalType(bindings.NewBooleanType())
 	queryParams["include_usages"] = "include_usages"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbServicesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbServicesTypes.go
@@ -58,7 +58,7 @@ func lbServicesDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["lb_service_id"] = "lbServiceId"
 	queryParams["force"] = "force"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -108,7 +108,7 @@ func lbServicesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbServiceId"] = bindings.NewStringType()
 	pathParams["lb_service_id"] = "lbServiceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func lbServicesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func lbServicesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbServiceId"] = bindings.NewStringType()
 	pathParams["lb_service_id"] = "lbServiceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func lbServicesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbServiceId"] = bindings.NewStringType()
 	pathParams["lb_service_id"] = "lbServiceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbSslCiphersAndProtocolsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbSslCiphersAndProtocolsTypes.go
@@ -81,7 +81,7 @@ func lbSslCiphersAndProtocolsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbVirtualServersTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/LbVirtualServersTypes.go
@@ -58,7 +58,7 @@ func lbVirtualServersDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["lb_virtual_server_id"] = "lbVirtualServerId"
 	queryParams["force"] = "force"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -108,7 +108,7 @@ func lbVirtualServersGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbVirtualServerId"] = bindings.NewStringType()
 	pathParams["lb_virtual_server_id"] = "lbVirtualServerId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func lbVirtualServersListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func lbVirtualServersPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbVirtualServerId"] = bindings.NewStringType()
 	pathParams["lb_virtual_server_id"] = "lbVirtualServerId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func lbVirtualServersUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["lbVirtualServerId"] = bindings.NewStringType()
 	pathParams["lb_virtual_server_id"] = "lbVirtualServerId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/MacDiscoveryProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/MacDiscoveryProfilesTypes.go
@@ -52,7 +52,7 @@ func macDiscoveryProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["macDiscoveryProfileId"] = bindings.NewStringType()
 	pathParams["mac_discovery_profile_id"] = "macDiscoveryProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func macDiscoveryProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["macDiscoveryProfileId"] = bindings.NewStringType()
 	pathParams["mac_discovery_profile_id"] = "macDiscoveryProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func macDiscoveryProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func macDiscoveryProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["macDiscoveryProfileId"] = bindings.NewStringType()
 	pathParams["mac_discovery_profile_id"] = "macDiscoveryProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func macDiscoveryProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["macDiscoveryProfileId"] = bindings.NewStringType()
 	pathParams["mac_discovery_profile_id"] = "macDiscoveryProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/MetadataProxiesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/MetadataProxiesTypes.go
@@ -52,7 +52,7 @@ func metadataProxiesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["metadataProxyId"] = bindings.NewStringType()
 	pathParams["metadata_proxy_id"] = "metadataProxyId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func metadataProxiesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["metadataProxyId"] = bindings.NewStringType()
 	pathParams["metadata_proxy_id"] = "metadataProxyId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func metadataProxiesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func metadataProxiesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["metadataProxyId"] = bindings.NewStringType()
 	pathParams["metadata_proxy_id"] = "metadataProxyId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func metadataProxiesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["metadataProxyId"] = bindings.NewStringType()
 	pathParams["metadata_proxy_id"] = "metadataProxyId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/OverriddenResourcesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/OverriddenResourcesTypes.go
@@ -57,7 +57,7 @@ func overriddenResourcesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["site_path"] = "site_path"
 	queryParams["intent_path"] = "intent_path"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/PartnerServicesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/PartnerServicesTypes.go
@@ -52,7 +52,7 @@ func partnerServicesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["serviceName"] = bindings.NewStringType()
 	pathParams["service_name"] = "serviceName"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -131,7 +131,7 @@ func partnerServicesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/PimProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/PimProfilesTypes.go
@@ -52,7 +52,7 @@ func pimProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["pimProfileId"] = bindings.NewStringType()
 	pathParams["pim_profile_id"] = "pimProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func pimProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["pimProfileId"] = bindings.NewStringType()
 	pathParams["pim_profile_id"] = "pimProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func pimProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func pimProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["pimProfileId"] = bindings.NewStringType()
 	pathParams["pim_profile_id"] = "pimProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func pimProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["pimProfileId"] = bindings.NewStringType()
 	pathParams["pim_profile_id"] = "pimProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/PortMirroringProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/PortMirroringProfilesTypes.go
@@ -52,7 +52,7 @@ func portMirroringProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["portMirroringProfileId"] = bindings.NewStringType()
 	pathParams["port_mirroring_profile_id"] = "portMirroringProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func portMirroringProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["portMirroringProfileId"] = bindings.NewStringType()
 	pathParams["port_mirroring_profile_id"] = "portMirroringProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -175,7 +175,7 @@ func portMirroringProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["sort_by"] = "sort_by"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -230,7 +230,7 @@ func portMirroringProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["portMirroringProfileId"] = bindings.NewStringType()
 	pathParams["port_mirroring_profile_id"] = "portMirroringProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -285,7 +285,7 @@ func portMirroringProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["portMirroringProfileId"] = bindings.NewStringType()
 	pathParams["port_mirroring_profile_id"] = "portMirroringProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/QosProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/QosProfilesTypes.go
@@ -52,7 +52,7 @@ func qosProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["qosProfileId"] = bindings.NewStringType()
 	pathParams["qos_profile_id"] = "qosProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func qosProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["qosProfileId"] = bindings.NewStringType()
 	pathParams["qos_profile_id"] = "qosProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -175,7 +175,7 @@ func qosProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["sort_by"] = "sort_by"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -230,7 +230,7 @@ func qosProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["qosProfileId"] = bindings.NewStringType()
 	pathParams["qos_profile_id"] = "qosProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -285,7 +285,7 @@ func qosProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["qosProfileId"] = bindings.NewStringType()
 	pathParams["qos_profile_id"] = "qosProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ReactionsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ReactionsTypes.go
@@ -52,7 +52,7 @@ func reactionsDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["reactionId"] = bindings.NewStringType()
 	pathParams["reaction_id"] = "reactionId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func reactionsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["reactionId"] = bindings.NewStringType()
 	pathParams["reaction_id"] = "reactionId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func reactionsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func reactionsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["reactionId"] = bindings.NewStringType()
 	pathParams["reaction_id"] = "reactionId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func reactionsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["reactionId"] = bindings.NewStringType()
 	pathParams["reaction_id"] = "reactionId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/SegmentSecurityProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/SegmentSecurityProfilesTypes.go
@@ -52,7 +52,7 @@ func segmentSecurityProfilesDeleteRestMetadata() protocol.OperationRestMetadata 
 	paramsTypeMap["segmentSecurityProfileId"] = bindings.NewStringType()
 	pathParams["segment_security_profile_id"] = "segmentSecurityProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func segmentSecurityProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["segmentSecurityProfileId"] = bindings.NewStringType()
 	pathParams["segment_security_profile_id"] = "segmentSecurityProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func segmentSecurityProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func segmentSecurityProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["segmentSecurityProfileId"] = bindings.NewStringType()
 	pathParams["segment_security_profile_id"] = "segmentSecurityProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func segmentSecurityProfilesUpdateRestMetadata() protocol.OperationRestMetadata 
 	paramsTypeMap["segmentSecurityProfileId"] = bindings.NewStringType()
 	pathParams["segment_security_profile_id"] = "segmentSecurityProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/SegmentsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/SegmentsTypes.go
@@ -52,7 +52,7 @@ func segmentsDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["segmentId"] = bindings.NewStringType()
 	pathParams["segment_id"] = "segmentId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func segmentsDelete0RestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["segmentId"] = bindings.NewStringType()
 	pathParams["segment_id"] = "segmentId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -152,7 +152,7 @@ func segmentsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["segmentId"] = bindings.NewStringType()
 	pathParams["segment_id"] = "segmentId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -231,7 +231,7 @@ func segmentsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -286,7 +286,7 @@ func segmentsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["segmentId"] = bindings.NewStringType()
 	pathParams["segment_id"] = "segmentId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -341,7 +341,7 @@ func segmentsPatch0RestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["segmentId"] = bindings.NewStringType()
 	pathParams["segment_id"] = "segmentId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -396,7 +396,7 @@ func segmentsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["segmentId"] = bindings.NewStringType()
 	pathParams["segment_id"] = "segmentId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -451,7 +451,7 @@ func segmentsUpdate0RestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["segmentId"] = bindings.NewStringType()
 	pathParams["segment_id"] = "segmentId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ServiceChainsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ServiceChainsTypes.go
@@ -52,7 +52,7 @@ func serviceChainsDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["serviceChainId"] = bindings.NewStringType()
 	pathParams["service_chain_id"] = "serviceChainId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func serviceChainsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["serviceChainId"] = bindings.NewStringType()
 	pathParams["service_chain_id"] = "serviceChainId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func serviceChainsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func serviceChainsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["serviceChainId"] = bindings.NewStringType()
 	pathParams["service_chain_id"] = "serviceChainId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func serviceChainsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["serviceChainId"] = bindings.NewStringType()
 	pathParams["service_chain_id"] = "serviceChainId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ServiceReferencesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ServiceReferencesTypes.go
@@ -58,7 +58,7 @@ func serviceReferencesDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["service_reference_id"] = "serviceReferenceId"
 	queryParams["cascade"] = "cascade"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -108,7 +108,7 @@ func serviceReferencesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["serviceReferenceId"] = bindings.NewStringType()
 	pathParams["service_reference_id"] = "serviceReferenceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func serviceReferencesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func serviceReferencesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["serviceReferenceId"] = bindings.NewStringType()
 	pathParams["service_reference_id"] = "serviceReferenceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func serviceReferencesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["serviceReferenceId"] = bindings.NewStringType()
 	pathParams["service_reference_id"] = "serviceReferenceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ServicesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ServicesTypes.go
@@ -52,7 +52,7 @@ func servicesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["serviceId"] = bindings.NewStringType()
 	pathParams["service_id"] = "serviceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func servicesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["serviceId"] = bindings.NewStringType()
 	pathParams["service_id"] = "serviceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func servicesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func servicesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["serviceId"] = bindings.NewStringType()
 	pathParams["service_id"] = "serviceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func servicesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["serviceId"] = bindings.NewStringType()
 	pathParams["service_id"] = "serviceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/SiteTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/SiteTypes.go
@@ -45,7 +45,7 @@ func siteOffboardRestMetadata() protocol.OperationRestMetadata {
 	dispatchHeaderParams := map[string]string{}
 	bodyFieldsMap := map[string]string{}
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/SitesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/SitesTypes.go
@@ -58,7 +58,7 @@ func sitesDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["site_id"] = "siteId"
 	queryParams["force"] = "force"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -108,7 +108,7 @@ func sitesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["siteId"] = bindings.NewStringType()
 	pathParams["site_id"] = "siteId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -187,7 +187,7 @@ func sitesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -242,7 +242,7 @@ func sitesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["siteId"] = bindings.NewStringType()
 	pathParams["site_id"] = "siteId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -297,7 +297,7 @@ func sitesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["siteId"] = bindings.NewStringType()
 	pathParams["site_id"] = "siteId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/SpanTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/SpanTypes.go
@@ -57,7 +57,7 @@ func spanGetRestMetadata() protocol.OperationRestMetadata {
 	queryParams["site_path"] = "site_path"
 	queryParams["intent_path"] = "intent_path"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/SpoofguardProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/SpoofguardProfilesTypes.go
@@ -52,7 +52,7 @@ func spoofguardProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["spoofguardProfileId"] = bindings.NewStringType()
 	pathParams["spoofguard_profile_id"] = "spoofguardProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func spoofguardProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["spoofguardProfileId"] = bindings.NewStringType()
 	pathParams["spoofguard_profile_id"] = "spoofguardProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func spoofguardProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func spoofguardProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["spoofguardProfileId"] = bindings.NewStringType()
 	pathParams["spoofguard_profile_id"] = "spoofguardProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func spoofguardProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["spoofguardProfileId"] = bindings.NewStringType()
 	pathParams["spoofguard_profile_id"] = "spoofguardProfileId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/TagsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/TagsTypes.go
@@ -107,7 +107,7 @@ func tagsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/Tier0sTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/Tier0sTypes.go
@@ -52,7 +52,7 @@ func tier0sDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tier0Id"] = bindings.NewStringType()
 	pathParams["tier0_id"] = "tier0Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func tier0sGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tier0Id"] = bindings.NewStringType()
 	pathParams["tier0_id"] = "tier0Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func tier0sListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func tier0sPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tier0Id"] = bindings.NewStringType()
 	pathParams["tier0_id"] = "tier0Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -292,7 +292,7 @@ func tier0sReprocessRestMetadata() protocol.OperationRestMetadata {
 	pathParams["tier0_id"] = "tier0Id"
 	queryParams["enforcement_point_path"] = "enforcement_point_path"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -347,7 +347,7 @@ func tier0sUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tier0Id"] = bindings.NewStringType()
 	pathParams["tier0_id"] = "tier0Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/Tier1sTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/Tier1sTypes.go
@@ -52,7 +52,7 @@ func tier1sDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tier1Id"] = bindings.NewStringType()
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func tier1sGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tier1Id"] = bindings.NewStringType()
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func tier1sListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func tier1sPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tier1Id"] = bindings.NewStringType()
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -292,7 +292,7 @@ func tier1sReprocessRestMetadata() protocol.OperationRestMetadata {
 	pathParams["tier1_id"] = "tier1Id"
 	queryParams["enforcement_point_path"] = "enforcement_point_path"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -347,7 +347,7 @@ func tier1sUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tier1Id"] = bindings.NewStringType()
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/TraceflowsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/TraceflowsTypes.go
@@ -58,7 +58,7 @@ func traceflowsCreateRestMetadata() protocol.OperationRestMetadata {
 	pathParams["traceflow_id"] = "traceflowId"
 	queryParams["action"] = "action"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -108,7 +108,7 @@ func traceflowsDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["traceflowId"] = bindings.NewStringType()
 	pathParams["traceflow_id"] = "traceflowId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -158,7 +158,7 @@ func traceflowsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["traceflowId"] = bindings.NewStringType()
 	pathParams["traceflow_id"] = "traceflowId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -237,7 +237,7 @@ func traceflowsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -292,7 +292,7 @@ func traceflowsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["traceflowId"] = bindings.NewStringType()
 	pathParams["traceflow_id"] = "traceflowId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -347,7 +347,7 @@ func traceflowsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["traceflowId"] = bindings.NewStringType()
 	pathParams["traceflow_id"] = "traceflowId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/UpgradeSummaryTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/UpgradeSummaryTypes.go
@@ -81,7 +81,7 @@ func upgradeSummaryListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["sort_by"] = "sort_by"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/UrlCategoriesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/UrlCategoriesTypes.go
@@ -81,7 +81,7 @@ func urlCategoriesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/UrlReputationSeveritiesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/UrlReputationSeveritiesTypes.go
@@ -81,7 +81,7 @@ func urlReputationSeveritiesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/VirtualMachineGroupAssociationsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/VirtualMachineGroupAssociationsTypes.go
@@ -93,7 +93,7 @@ func virtualMachineGroupAssociationsListRestMetadata() protocol.OperationRestMet
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/VirtualNetworkInterfaceGroupAssociationsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/VirtualNetworkInterfaceGroupAssociationsTypes.go
@@ -93,7 +93,7 @@ func virtualNetworkInterfaceGroupAssociationsListRestMetadata() protocol.Operati
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/VniPoolsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/VniPoolsTypes.go
@@ -52,7 +52,7 @@ func vniPoolsDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["vniPoolId"] = bindings.NewStringType()
 	pathParams["vni_pool_id"] = "vniPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -102,7 +102,7 @@ func vniPoolsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["vniPoolId"] = bindings.NewStringType()
 	pathParams["vni_pool_id"] = "vniPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -181,7 +181,7 @@ func vniPoolsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -236,7 +236,7 @@ func vniPoolsPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["vniPoolId"] = bindings.NewStringType()
 	pathParams["vni_pool_id"] = "vniPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -291,7 +291,7 @@ func vniPoolsUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["vniPoolId"] = bindings.NewStringType()
 	pathParams["vni_pool_id"] = "vniPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ip_pools/IpAllocationsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ip_pools/IpAllocationsTypes.go
@@ -59,7 +59,7 @@ func ipAllocationsDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["ip_allocation_id"] = "ipAllocationId"
 	pathParams["ip_pool_id"] = "ipPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -116,7 +116,7 @@ func ipAllocationsGetRestMetadata() protocol.OperationRestMetadata {
 	pathParams["ip_allocation_id"] = "ipAllocationId"
 	pathParams["ip_pool_id"] = "ipPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -202,7 +202,7 @@ func ipAllocationsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -264,7 +264,7 @@ func ipAllocationsPatchRestMetadata() protocol.OperationRestMetadata {
 	pathParams["ip_allocation_id"] = "ipAllocationId"
 	pathParams["ip_pool_id"] = "ipPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -326,7 +326,7 @@ func ipAllocationsUpdateRestMetadata() protocol.OperationRestMetadata {
 	pathParams["ip_allocation_id"] = "ipAllocationId"
 	pathParams["ip_pool_id"] = "ipPoolId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ip_pools/IpSubnetsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ip_pools/IpSubnetsTypes.go
@@ -59,7 +59,7 @@ func ipSubnetsDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["ip_pool_id"] = "ipPoolId"
 	pathParams["ip_subnet_id"] = "ipSubnetId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -116,7 +116,7 @@ func ipSubnetsGetRestMetadata() protocol.OperationRestMetadata {
 	pathParams["ip_pool_id"] = "ipPoolId"
 	pathParams["ip_subnet_id"] = "ipSubnetId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -202,7 +202,7 @@ func ipSubnetsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -264,7 +264,7 @@ func ipSubnetsPatchRestMetadata() protocol.OperationRestMetadata {
 	pathParams["ip_pool_id"] = "ipPoolId"
 	pathParams["ip_subnet_id"] = "ipSubnetId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -326,7 +326,7 @@ func ipSubnetsUpdateRestMetadata() protocol.OperationRestMetadata {
 	pathParams["ip_pool_id"] = "ipPoolId"
 	pathParams["ip_subnet_id"] = "ipSubnetId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/AlarmsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/AlarmsTypes.go
@@ -75,7 +75,7 @@ func alarmsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["sort_by"] = "sort_by"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/EnforcementPointsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/EnforcementPointsTypes.go
@@ -52,7 +52,7 @@ func enforcementPointsGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["enforcementPointName"] = bindings.NewStringType()
 	pathParams["enforcement_point_name"] = "enforcementPointName"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -125,7 +125,7 @@ func enforcementPointsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["sort_by"] = "sort_by"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/RealizedEntitiesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/RealizedEntitiesTypes.go
@@ -57,7 +57,7 @@ func realizedEntitiesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["site_path"] = "site_path"
 	queryParams["intent_path"] = "intent_path"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/RealizedEntityTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/RealizedEntityTypes.go
@@ -51,7 +51,7 @@ func realizedEntityGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["realized_path"] = bindings.NewStringType()
 	queryParams["realized_path"] = "realized_path"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -106,7 +106,7 @@ func realizedEntityRefreshRestMetadata() protocol.OperationRestMetadata {
 	queryParams["enforcement_point_path"] = "enforcement_point_path"
 	queryParams["intent_path"] = "intent_path"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/StatusTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/StatusTypes.go
@@ -63,7 +63,7 @@ func statusGetRestMetadata() protocol.OperationRestMetadata {
 	queryParams["intent_path"] = "intent_path"
 	queryParams["include_enforced_status"] = "include_enforced_status"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/UnassociatedVirtualMachinesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/UnassociatedVirtualMachinesTypes.go
@@ -87,7 +87,7 @@ func unassociatedVirtualMachinesListRestMetadata() protocol.OperationRestMetadat
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/VirtualMachinesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/realized_state/VirtualMachinesTypes.go
@@ -87,7 +87,7 @@ func virtualMachinesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/sites/enforcement_points/EdgeBridgeProfilesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/sites/enforcement_points/EdgeBridgeProfilesTypes.go
@@ -66,7 +66,7 @@ func edgeBridgeProfilesDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["site_id"] = "siteId"
 	pathParams["enforcement_point_id"] = "enforcementPointId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -130,7 +130,7 @@ func edgeBridgeProfilesGetRestMetadata() protocol.OperationRestMetadata {
 	pathParams["site_id"] = "siteId"
 	pathParams["enforcement_point_id"] = "enforcementPointId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -217,7 +217,7 @@ func edgeBridgeProfilesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["sort_by"] = "sort_by"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -286,7 +286,7 @@ func edgeBridgeProfilesPatchRestMetadata() protocol.OperationRestMetadata {
 	pathParams["site_id"] = "siteId"
 	pathParams["enforcement_point_id"] = "enforcementPointId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -355,7 +355,7 @@ func edgeBridgeProfilesUpdateRestMetadata() protocol.OperationRestMetadata {
 	pathParams["site_id"] = "siteId"
 	pathParams["enforcement_point_id"] = "enforcementPointId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/sites/enforcement_points/EdgeClustersTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/sites/enforcement_points/EdgeClustersTypes.go
@@ -66,7 +66,7 @@ func edgeClustersGetRestMetadata() protocol.OperationRestMetadata {
 	pathParams["site_id"] = "siteId"
 	pathParams["edge_cluster_id"] = "edgeClusterId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -159,7 +159,7 @@ func edgeClustersListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/sites/enforcement_points/TransportZonesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/sites/enforcement_points/TransportZonesTypes.go
@@ -66,7 +66,7 @@ func transportZonesGetRestMetadata() protocol.OperationRestMetadata {
 	pathParams["transport_zone_id"] = "transportZoneId"
 	pathParams["site_id"] = "siteId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -159,7 +159,7 @@ func transportZonesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/DnsForwarderTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/DnsForwarderTypes.go
@@ -66,7 +66,7 @@ func dnsForwarderCreateRestMetadata() protocol.OperationRestMetadata {
 	queryParams["action"] = "action"
 	queryParams["enforcement_point_path"] = "enforcement_point_path"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -116,7 +116,7 @@ func dnsForwarderDeleteRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tier1Id"] = bindings.NewStringType()
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -166,7 +166,7 @@ func dnsForwarderGetRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tier1Id"] = bindings.NewStringType()
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -221,7 +221,7 @@ func dnsForwarderPatchRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tier1Id"] = bindings.NewStringType()
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -276,7 +276,7 @@ func dnsForwarderUpdateRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tier1Id"] = bindings.NewStringType()
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/FloodProtectionProfileBindingsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/FloodProtectionProfileBindingsTypes.go
@@ -59,7 +59,7 @@ func floodProtectionProfileBindingsDeleteRestMetadata() protocol.OperationRestMe
 	pathParams["tier1_id"] = "tier1Id"
 	pathParams["flood_protection_profile_binding_id"] = "floodProtectionProfileBindingId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -116,7 +116,7 @@ func floodProtectionProfileBindingsGetRestMetadata() protocol.OperationRestMetad
 	pathParams["tier1_id"] = "tier1Id"
 	pathParams["flood_protection_profile_binding_id"] = "floodProtectionProfileBindingId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -178,7 +178,7 @@ func floodProtectionProfileBindingsPatchRestMetadata() protocol.OperationRestMet
 	pathParams["tier1_id"] = "tier1Id"
 	pathParams["flood_protection_profile_binding_id"] = "floodProtectionProfileBindingId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -240,7 +240,7 @@ func floodProtectionProfileBindingsUpdateRestMetadata() protocol.OperationRestMe
 	pathParams["tier1_id"] = "tier1Id"
 	pathParams["flood_protection_profile_binding_id"] = "floodProtectionProfileBindingId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/ForwardingTableTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/ForwardingTableTypes.go
@@ -118,7 +118,7 @@ func forwardingTableListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["route_source"] = "route_source"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/GatewayFirewallTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/GatewayFirewallTypes.go
@@ -52,7 +52,7 @@ func gatewayFirewallListRestMetadata() protocol.OperationRestMetadata {
 	paramsTypeMap["tier1Id"] = bindings.NewStringType()
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/IpfixSwitchCollectionInstancesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/IpfixSwitchCollectionInstancesTypes.go
@@ -59,7 +59,7 @@ func ipfixSwitchCollectionInstancesDeleteRestMetadata() protocol.OperationRestMe
 	pathParams["tier1_id"] = "tier1Id"
 	pathParams["ipfix_switch_collection_instance_id"] = "ipfixSwitchCollectionInstanceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -116,7 +116,7 @@ func ipfixSwitchCollectionInstancesGetRestMetadata() protocol.OperationRestMetad
 	pathParams["tier1_id"] = "tier1Id"
 	pathParams["ipfix_switch_collection_instance_id"] = "ipfixSwitchCollectionInstanceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -202,7 +202,7 @@ func ipfixSwitchCollectionInstancesListRestMetadata() protocol.OperationRestMeta
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -264,7 +264,7 @@ func ipfixSwitchCollectionInstancesPatchRestMetadata() protocol.OperationRestMet
 	pathParams["tier1_id"] = "tier1Id"
 	pathParams["ipfix_switch_collection_instance_id"] = "ipfixSwitchCollectionInstanceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -326,7 +326,7 @@ func ipfixSwitchCollectionInstancesUpdateRestMetadata() protocol.OperationRestMe
 	pathParams["tier1_id"] = "tier1Id"
 	pathParams["ipfix_switch_collection_instance_id"] = "ipfixSwitchCollectionInstanceId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/LocaleServicesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/LocaleServicesTypes.go
@@ -59,7 +59,7 @@ func localeServicesDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["locale_services_id"] = "localeServicesId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -116,7 +116,7 @@ func localeServicesGetRestMetadata() protocol.OperationRestMetadata {
 	pathParams["locale_services_id"] = "localeServicesId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -202,7 +202,7 @@ func localeServicesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -264,7 +264,7 @@ func localeServicesPatchRestMetadata() protocol.OperationRestMetadata {
 	pathParams["locale_services_id"] = "localeServicesId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -326,7 +326,7 @@ func localeServicesUpdateRestMetadata() protocol.OperationRestMetadata {
 	pathParams["locale_services_id"] = "localeServicesId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/SegmentsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/SegmentsTypes.go
@@ -59,7 +59,7 @@ func segmentsDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["segment_id"] = "segmentId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -116,7 +116,7 @@ func segmentsDelete0RestMetadata() protocol.OperationRestMetadata {
 	pathParams["segment_id"] = "segmentId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -173,7 +173,7 @@ func segmentsGetRestMetadata() protocol.OperationRestMetadata {
 	pathParams["segment_id"] = "segmentId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -259,7 +259,7 @@ func segmentsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -321,7 +321,7 @@ func segmentsPatchRestMetadata() protocol.OperationRestMetadata {
 	pathParams["segment_id"] = "segmentId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -383,7 +383,7 @@ func segmentsUpdateRestMetadata() protocol.OperationRestMetadata {
 	pathParams["segment_id"] = "segmentId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/SessionTimerProfileBindingsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/SessionTimerProfileBindingsTypes.go
@@ -59,7 +59,7 @@ func sessionTimerProfileBindingsDeleteRestMetadata() protocol.OperationRestMetad
 	pathParams["tier1_id"] = "tier1Id"
 	pathParams["session_timer_profile_binding_id"] = "sessionTimerProfileBindingId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -116,7 +116,7 @@ func sessionTimerProfileBindingsGetRestMetadata() protocol.OperationRestMetadata
 	pathParams["tier1_id"] = "tier1Id"
 	pathParams["session_timer_profile_binding_id"] = "sessionTimerProfileBindingId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -178,7 +178,7 @@ func sessionTimerProfileBindingsPatchRestMetadata() protocol.OperationRestMetada
 	pathParams["tier1_id"] = "tier1Id"
 	pathParams["session_timer_profile_binding_id"] = "sessionTimerProfileBindingId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -240,7 +240,7 @@ func sessionTimerProfileBindingsUpdateRestMetadata() protocol.OperationRestMetad
 	pathParams["tier1_id"] = "tier1Id"
 	pathParams["session_timer_profile_binding_id"] = "sessionTimerProfileBindingId"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/StateTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/StateTypes.go
@@ -94,7 +94,7 @@ func stateGetRestMetadata() protocol.OperationRestMetadata {
 	queryParams["sort_by"] = "sort_by"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/StaticRoutesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/StaticRoutesTypes.go
@@ -59,7 +59,7 @@ func staticRoutesDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["route_id"] = "routeId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -116,7 +116,7 @@ func staticRoutesGetRestMetadata() protocol.OperationRestMetadata {
 	pathParams["route_id"] = "routeId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -202,7 +202,7 @@ func staticRoutesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -264,7 +264,7 @@ func staticRoutesPatchRestMetadata() protocol.OperationRestMetadata {
 	pathParams["route_id"] = "routeId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -326,7 +326,7 @@ func staticRoutesUpdateRestMetadata() protocol.OperationRestMetadata {
 	pathParams["route_id"] = "routeId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/nat/NatRulesTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/nat/NatRulesTypes.go
@@ -66,7 +66,7 @@ func natRulesDeleteRestMetadata() protocol.OperationRestMetadata {
 	pathParams["nat_id"] = "natId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -130,7 +130,7 @@ func natRulesGetRestMetadata() protocol.OperationRestMetadata {
 	pathParams["nat_id"] = "natId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -223,7 +223,7 @@ func natRulesListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -292,7 +292,7 @@ func natRulesPatchRestMetadata() protocol.OperationRestMetadata {
 	pathParams["nat_id"] = "natId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,
@@ -361,7 +361,7 @@ func natRulesUpdateRestMetadata() protocol.OperationRestMetadata {
 	pathParams["nat_id"] = "natId"
 	pathParams["tier1_id"] = "tier1Id"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/nat/StatisticsTypes.go
+++ b/vendor/github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/tier_1s/nat/StatisticsTypes.go
@@ -94,7 +94,7 @@ func statisticsListRestMetadata() protocol.OperationRestMetadata {
 	queryParams["include_mark_for_delete_objects"] = "include_mark_for_delete_objects"
 	queryParams["page_size"] = "page_size"
 	resultHeaders := map[string]string{}
-	errorHeaders := map[string]string{}
+	errorHeaders := map[string]map[string]string{}
 	return protocol.NewOperationRestMetadata(
 		fields,
 		fieldNameMap,

--- a/vendor/golang.org/x/net/http2/client_conn_pool.go
+++ b/vendor/golang.org/x/net/http2/client_conn_pool.go
@@ -107,6 +107,7 @@ func (p *clientConnPool) getClientConn(req *http.Request, addr string, dialOnMis
 
 // dialCall is an in-flight Transport dial call to a host.
 type dialCall struct {
+	_    incomparable
 	p    *clientConnPool
 	done chan struct{} // closed when done
 	res  *ClientConn   // valid after done is closed
@@ -180,6 +181,7 @@ func (p *clientConnPool) addConnIfNeeded(key string, t *Transport, c *tls.Conn) 
 }
 
 type addConnCall struct {
+	_    incomparable
 	p    *clientConnPool
 	done chan struct{} // closed when done
 	err  error
@@ -198,12 +200,6 @@ func (c *addConnCall) run(t *Transport, key string, tc *tls.Conn) {
 	delete(p.addConnCalls, key)
 	p.mu.Unlock()
 	close(c.done)
-}
-
-func (p *clientConnPool) addConn(key string, cc *ClientConn) {
-	p.mu.Lock()
-	p.addConnLocked(key, cc)
-	p.mu.Unlock()
 }
 
 // p.mu must be held

--- a/vendor/golang.org/x/net/http2/flow.go
+++ b/vendor/golang.org/x/net/http2/flow.go
@@ -8,6 +8,8 @@ package http2
 
 // flow is the flow control window's size.
 type flow struct {
+	_ incomparable
+
 	// n is the number of DATA bytes we're allowed to send.
 	// A flow is kept both on a conn and a per-stream.
 	n int32

--- a/vendor/golang.org/x/net/http2/hpack/huffman.go
+++ b/vendor/golang.org/x/net/http2/hpack/huffman.go
@@ -105,7 +105,14 @@ func huffmanDecode(buf *bytes.Buffer, maxLen int, v []byte) error {
 	return nil
 }
 
+// incomparable is a zero-width, non-comparable type. Adding it to a struct
+// makes that struct also non-comparable, and generally doesn't add
+// any size (as long as it's first).
+type incomparable [0]func()
+
 type node struct {
+	_ incomparable
+
 	// children is non-nil for internal nodes
 	children *[256]*node
 

--- a/vendor/golang.org/x/net/http2/http2.go
+++ b/vendor/golang.org/x/net/http2/http2.go
@@ -241,6 +241,7 @@ func (cw closeWaiter) Wait() {
 // Its buffered writer is lazily allocated as needed, to minimize
 // idle memory usage with many connections.
 type bufferedWriter struct {
+	_  incomparable
 	w  io.Writer     // immutable
 	bw *bufio.Writer // non-nil when data is buffered
 }
@@ -313,6 +314,7 @@ func bodyAllowedForStatus(status int) bool {
 }
 
 type httpError struct {
+	_       incomparable
 	msg     string
 	timeout bool
 }
@@ -376,3 +378,8 @@ func (s *sorter) SortStrings(ss []string) {
 func validPseudoPath(v string) bool {
 	return (len(v) > 0 && v[0] == '/') || v == "*"
 }
+
+// incomparable is a zero-width, non-comparable type. Adding it to a struct
+// makes that struct also non-comparable, and generally doesn't add
+// any size (as long as it's first).
+type incomparable [0]func()

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -108,6 +108,19 @@ type Transport struct {
 	// waiting for their turn.
 	StrictMaxConcurrentStreams bool
 
+	// ReadIdleTimeout is the timeout after which a health check using ping
+	// frame will be carried out if no frame is received on the connection.
+	// Note that a ping response will is considered a received frame, so if
+	// there is no other traffic on the connection, the health check will
+	// be performed every ReadIdleTimeout interval.
+	// If zero, no health check is performed.
+	ReadIdleTimeout time.Duration
+
+	// PingTimeout is the timeout after which the connection will be closed
+	// if a response to Ping is not received.
+	// Defaults to 15s.
+	PingTimeout time.Duration
+
 	// t1, if non-nil, is the standard library Transport using
 	// this transport. Its settings are used (but not its
 	// RoundTrip method, etc).
@@ -129,6 +142,14 @@ func (t *Transport) maxHeaderListSize() uint32 {
 
 func (t *Transport) disableCompression() bool {
 	return t.DisableCompression || (t.t1 != nil && t.t1.DisableCompression)
+}
+
+func (t *Transport) pingTimeout() time.Duration {
+	if t.PingTimeout == 0 {
+		return 15 * time.Second
+	}
+	return t.PingTimeout
+
 }
 
 // ConfigureTransport configures a net/http HTTP/1 Transport to use HTTP/2.
@@ -675,6 +696,20 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
 	return cc, nil
 }
 
+func (cc *ClientConn) healthCheck() {
+	pingTimeout := cc.t.pingTimeout()
+	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
+	// trigger the healthCheck again if there is no frame received.
+	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
+	defer cancel()
+	err := cc.Ping(ctx)
+	if err != nil {
+		cc.closeForLostPing()
+		cc.t.connPool().MarkDead(cc)
+		return
+	}
+}
+
 func (cc *ClientConn) setGoAway(f *GoAwayFrame) {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
@@ -846,14 +881,12 @@ func (cc *ClientConn) sendGoAway() error {
 	return nil
 }
 
-// Close closes the client connection immediately.
-//
-// In-flight requests are interrupted. For a graceful shutdown, use Shutdown instead.
-func (cc *ClientConn) Close() error {
+// closes the client connection immediately. In-flight requests are interrupted.
+// err is sent to streams.
+func (cc *ClientConn) closeForError(err error) error {
 	cc.mu.Lock()
 	defer cc.cond.Broadcast()
 	defer cc.mu.Unlock()
-	err := errors.New("http2: client connection force closed via ClientConn.Close")
 	for id, cs := range cc.streams {
 		select {
 		case cs.resc <- resAndError{err: err}:
@@ -864,6 +897,20 @@ func (cc *ClientConn) Close() error {
 	}
 	cc.closed = true
 	return cc.tconn.Close()
+}
+
+// Close closes the client connection immediately.
+//
+// In-flight requests are interrupted. For a graceful shutdown, use Shutdown instead.
+func (cc *ClientConn) Close() error {
+	err := errors.New("http2: client connection force closed via ClientConn.Close")
+	return cc.closeForError(err)
+}
+
+// closes the client connection immediately. In-flight requests are interrupted.
+func (cc *ClientConn) closeForLostPing() error {
+	err := errors.New("http2: client connection lost")
+	return cc.closeForError(err)
 }
 
 const maxAllocFrameSize = 512 << 10
@@ -916,7 +963,7 @@ func commaSeparatedTrailers(req *http.Request) (string, error) {
 		k = http.CanonicalHeaderKey(k)
 		switch k {
 		case "Transfer-Encoding", "Trailer", "Content-Length":
-			return "", &badStringError{"invalid Trailer key", k}
+			return "", fmt.Errorf("invalid Trailer key %q", k)
 		}
 		keys = append(keys, k)
 	}
@@ -1394,13 +1441,6 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error) 
 	}
 }
 
-type badStringError struct {
-	what string
-	str  string
-}
-
-func (e *badStringError) Error() string { return fmt.Sprintf("%s %q", e.what, e.str) }
-
 // requires cc.mu be held.
 func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trailers string, contentLength int64) ([]byte, error) {
 	cc.hbuf.Reset()
@@ -1616,6 +1656,7 @@ func (cc *ClientConn) writeHeader(name, value string) {
 }
 
 type resAndError struct {
+	_   incomparable
 	res *http.Response
 	err error
 }
@@ -1663,6 +1704,7 @@ func (cc *ClientConn) streamByID(id uint32, andRemove bool) *clientStream {
 
 // clientConnReadLoop is the state owned by the clientConn's frame-reading readLoop.
 type clientConnReadLoop struct {
+	_             incomparable
 	cc            *ClientConn
 	closeWhenIdle bool
 }
@@ -1742,8 +1784,17 @@ func (rl *clientConnReadLoop) run() error {
 	rl.closeWhenIdle = cc.t.disableKeepAlives() || cc.singleUse
 	gotReply := false // ever saw a HEADERS reply
 	gotSettings := false
+	readIdleTimeout := cc.t.ReadIdleTimeout
+	var t *time.Timer
+	if readIdleTimeout != 0 {
+		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
+		defer t.Stop()
+	}
 	for {
 		f, err := cc.fr.ReadFrame()
+		if t != nil {
+			t.Reset(readIdleTimeout)
+		}
 		if err != nil {
 			cc.vlogf("http2: Transport readFrame error on conn %p: (%T) %v", cc, err, err)
 		}
@@ -2479,6 +2530,7 @@ func (rt erringRoundTripper) RoundTrip(*http.Request) (*http.Response, error) { 
 // gzipReader wraps a response body so it can lazily
 // call gzip.NewReader on the first call to Read
 type gzipReader struct {
+	_    incomparable
 	body io.ReadCloser // underlying Response.Body
 	zr   *gzip.Reader  // lazily-initialized gzip reader
 	zerr error         // sticky error

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -445,11 +445,11 @@ github.com/vmware/govmomi/vim25/xml
 github.com/vmware/govmomi/vslm
 github.com/vmware/govmomi/vslm/methods
 github.com/vmware/govmomi/vslm/types
-# github.com/vmware/vsphere-automation-sdk-go/lib v0.2.0
+# github.com/vmware/vsphere-automation-sdk-go/lib v0.3.1
 ## explicit
 github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std
 github.com/vmware/vsphere-automation-sdk-go/lib/vapi/std/errors
-# github.com/vmware/vsphere-automation-sdk-go/runtime v0.2.0
+# github.com/vmware/vsphere-automation-sdk-go/runtime v0.3.1
 ## explicit
 github.com/vmware/vsphere-automation-sdk-go/runtime/bindings
 github.com/vmware/vsphere-automation-sdk-go/runtime/common
@@ -470,7 +470,7 @@ github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/client/metadata
 github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/server
 github.com/vmware/vsphere-automation-sdk-go/runtime/protocol/server/rpc/msg
 github.com/vmware/vsphere-automation-sdk-go/runtime/security
-# github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.3.0
+# github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.4.0
 ## explicit
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra
 github.com/vmware/vsphere-automation-sdk-go/services/nsxt/infra/ip_pools
@@ -514,7 +514,7 @@ golang.org/x/mod/internal/lazyregexp
 golang.org/x/mod/modfile
 golang.org/x/mod/module
 golang.org/x/mod/semver
-# golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
+# golang.org/x/net v0.0.0-20200602114024-627f9648deb9
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/html


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area robustness
/kind task
/priority normal
/platform vmware

**What this PR does / why we need it**:
Restrict clusterID used for CSI to 63 characters, as there is 64 ch limit in vCenter CNS.
Also removed obsolete csi2 flag

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
restrict clusterID used for CSI to 63 characters
```
