### PR TITLE
set FailureDomainLabels for csi-vsphere.conf

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -21,7 +21,7 @@ If multiple identifiers make sense you can also state the commands multiple time
 /area TODO
 /kind bug
 /priority normal
-/platform vmware
+/platform vsphere
 
 **What happened**:
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -21,7 +21,7 @@ If multiple identifiers make sense you can also state the commands multiple time
 /area TODO
 /kind enhancement
 /priority normal
-/platform vmware
+/platform vsphere
 
 **What would you like to be added**:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ For Gardener Enhancement Proposals (GEPs), please check the following [documenta
 /area TODO
 /kind TODO
 /priority normal
-/platform vmware
+/platform vsphere
 
 **What this PR does / why we need it**:
 

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/_helpers.tpl
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/_helpers.tpl
@@ -8,4 +8,12 @@ datacenters = "{{ .Values.datacenters }}"
 user = "{{ .Values.username }}"
 password = "{{ .Values.password }}"
 insecure-flag = "{{ .Values.insecureFlag }}"
+
+[Labels]
+{{- if .Values.labelRegion }}
+region = "{{ .Values.labelRegion }}"
+{{- end }}
+{{- if .Values.labelZone }}
+zone = "{{ .Values.labelZone }}"
+{{- end }}
 {{- end -}}

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/values.yaml
@@ -16,6 +16,10 @@ datacenters: dc1
 insecureFlag: true
 resizerEnabled: false
 loggerLevel: PRODUCTION
+
+#labelRegion: k8s-region
+#labelZone: k8s-zone
+
 resources:
   attacher:
     requests:

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/templates/_helpers.tpl
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/templates/_helpers.tpl
@@ -8,6 +8,14 @@ datacenters = "{{ .Values.datacenters }}"
 user = "{{ .Values.username }}"
 password = "{{ .Values.password }}"
 insecure-flag = "{{ .Values.insecureFlag }}"
+
+[Labels]
+{{- if .Values.labelRegion }}
+region = "{{ .Values.labelRegion }}"
+{{- end }}
+{{- if .Values.labelZone }}
+zone = "{{ .Values.labelZone }}"
+{{- end }}
 {{- end -}}
 
 {{- define "csi-driver-node.extensionsGroup" -}}

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/values.yaml
@@ -11,3 +11,6 @@ datacenters: dc1
 insecureFlag: true
 # topology-aware setup
 topologyAware: true
+
+#labelRegion: k8s-region
+#labelZone: k8s-zone

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -550,6 +550,11 @@ func (vp *valuesProvider) getControlPlaneChartValues(
 		values["vsphere-cloud-controller-manager"].(map[string]interface{})["featureGates"] = cpConfig.CloudControllerManager.FeatureGates
 	}
 
+	if cloudProfileConfig.FailureDomainLabels != nil {
+		values["csi-vsphere"].(map[string]interface{})["labelRegion"] = cloudProfileConfig.FailureDomainLabels.Region
+		values["csi-vsphere"].(map[string]interface{})["labelZone"] = cloudProfileConfig.FailureDomainLabels.Zone
+	}
+
 	return values, nil
 }
 
@@ -592,6 +597,11 @@ func (vp *valuesProvider) getControlPlaneShootChartValues(
 			"insecureFlag":      insecureFlag,
 			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
 		},
+	}
+
+	if cloudProfileConfig.FailureDomainLabels != nil {
+		values["csi-vsphere"].(map[string]interface{})["labelRegion"] = cloudProfileConfig.FailureDomainLabels.Region
+		values["csi-vsphere"].(map[string]interface{})["labelZone"] = cloudProfileConfig.FailureDomainLabels.Zone
 	}
 
 	return values, nil

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -136,6 +136,10 @@ var _ = Describe("ValuesProvider", func() {
 								},
 							},
 							DNSServers: []string{"1.2.3.4"},
+							FailureDomainLabels: &apisvspherev1alpha1.FailureDomainLabels{
+								Region: "k8s-region",
+								Zone:   "k8s-zone",
+							},
 							Constraints: apisvspherev1alpha1.Constraints{
 								LoadBalancerConfig: apisvspherev1alpha1.LoadBalancerConfig{
 									Size: "MEDIUM",
@@ -270,6 +274,8 @@ insecure-flag = "true"
 				"usernameNE":   "nsxt-ne",
 				"remoteAuth":   true,
 			},
+			"labelRegion": "k8s-region",
+			"labelZone":   "k8s-zone",
 		}
 
 		controlPlaneChartValues = map[string]interface{}{
@@ -311,6 +317,8 @@ insecure-flag = "true"
 					"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
 					"checksum/secret-" + vsphere.SecretCSIVsphereConfig:           "a93175a6208bed98639833cf08f616d3329884d2558c1b61cde3656f2a57b5be",
 				},
+				"labelRegion": "k8s-region",
+				"labelZone":   "k8s-zone",
 			},
 		}
 
@@ -324,6 +332,8 @@ insecure-flag = "true"
 				"datacenters":       "scc01-DC",
 				"insecureFlag":      "true",
 				"kubernetesVersion": "1.14.0",
+				"labelRegion":       "k8s-region",
+				"labelZone":         "k8s-zone",
 			},
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal
/platform vmware

**What this PR does / why we need it**:
Provide domain labels for topology keys to CSI to  support multi availability zones.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
