### PR TITLE
authorize shoot specific IP pools and T1 gateway

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -58,12 +58,14 @@ infrastructureConfig:
 By default, the infrastructure controller creates a separate Tier-1 gateway for each shoot cluster
 and the cloud controller manager (`vsphere-cloud-provider`) creates a load balancer service.
 
-If an existing tier-1 gateway should be used, you can specify its 'path'. In this case, there
+If an existing Tier-1 gateway should be used, you can specify its 'path'. In this case, there
 must also be a load balancer service defined for this tier-1 gateway and its 'path' needs to be specified, too.
 In the NSX-T manager UI, the path of the tier-1 gateway can be found at `Networking / Tier-1 Gateways`.
 Then select `Copy path to clipboard` from the context menu of the tier-1 gateway 
 (click on the three vertical dots on the left of the row). Do the same with the 
 corresponding load balancer at `Networking / Load balancing / Tab Load Balancers`
+For security reasons the referenced Tier-1 gateway in NSX-T must have a tag with scope `authorized-shoots` and its
+tag value consists of a comma-separated list of the allowed shoot names (optionally with wildcard `*`)
 
 Example:
 
@@ -111,6 +113,8 @@ The specified names must be defined in the constraints section of the cloud prof
 If the list contains a load balancer named "default", it is used as the default load balancer.
 Otherwise the first one is also the default.
 If no classes are specified the default load balancer class is used as defined in the cloud profile constraints section.
+If the ipPoolName is overwritten, the IP pool object in NSX-T must have a tag with scope `authorized-shoots` and its
+tag value consists of a comma-separated list of the allowed shoot names (optionally with wildcard `*`)
 
 The `loadBalancerSize` is optional and overwrites the default value specified in the cloud profile config.
 It must be one of the values `SMALL`, `MEDIUM`, or `LARGE`. `SMALL` can manage 10 service ports,

--- a/pkg/cmd/infra-cli/create.go
+++ b/pkg/cmd/infra-cli/create.go
@@ -27,7 +27,7 @@ import (
 )
 
 func CreateInfrastructure(logger logr.Logger, cfg *infrastructure.NSXTConfig, specString string, fixedVersion *string) (*string, error) {
-	infrastructureEnsurer, err := ensurer.NewNSXTInfrastructureEnsurer(logger, cfg)
+	infrastructureEnsurer, err := ensurer.NewNSXTInfrastructureEnsurer(logger, cfg, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating ensurer failed")
 	}

--- a/pkg/cmd/infra-cli/destroy.go
+++ b/pkg/cmd/infra-cli/destroy.go
@@ -34,7 +34,7 @@ func DestroyInfrastructure(logger logr.Logger, cfg *infrastructure.NSXTConfig, s
 	if stateString == nil && specString == nil {
 		return nil, fmt.Errorf("Either state or spec is needed to destroy infrastructure")
 	}
-	infrastructureEnsurer, err := ensurer.NewNSXTInfrastructureEnsurer(logger, cfg)
+	infrastructureEnsurer, err := ensurer.NewNSXTInfrastructureEnsurer(logger, cfg, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating ensurer failed")
 	}

--- a/pkg/cmd/infra-cli/ippools.go
+++ b/pkg/cmd/infra-cli/ippools.go
@@ -42,7 +42,7 @@ import (
 )
 
 func CreateIPPool(logger logr.Logger, cfg *infrastructure.NSXTConfig, ipPoolName, ipPoolRanges, ipPoolCidr string, advancedAPI bool) error {
-	infrastructureEnsurer, err := ensurer.NewNSXTInfrastructureEnsurer(logger, cfg)
+	infrastructureEnsurer, err := ensurer.NewNSXTInfrastructureEnsurer(logger, cfg, nil)
 	if err != nil {
 		return errors.Wrapf(err, "creating ensurer failed")
 	}
@@ -179,7 +179,7 @@ func ipAddressPoolStaticSubnetToStructValue(poolPath *string, ipPoolName, ipPool
 }
 
 func DeleteIPPool(logger logr.Logger, cfg *infrastructure.NSXTConfig, ipPoolName string, advancedAPI bool) error {
-	infrastructureEnsurer, err := ensurer.NewNSXTInfrastructureEnsurer(logger, cfg)
+	infrastructureEnsurer, err := ensurer.NewNSXTInfrastructureEnsurer(logger, cfg, nil)
 	if err != nil {
 		return errors.Wrapf(err, "creating ensurer failed")
 	}

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -420,7 +420,6 @@ insecure-flag = "true"
 			Expect(len(short4)).To(Equal(63))
 		})
 	})
-
 })
 
 func encode(obj runtime.Object) []byte {

--- a/pkg/vsphere/helpers/helpers.go
+++ b/pkg/vsphere/helpers/helpers.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package helpers
+
+import (
+	api "github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/vsphere"
+	"github.com/gardener/gardener-extension-provider-vsphere/pkg/vsphere"
+	"github.com/gardener/gardener-extension-provider-vsphere/pkg/vsphere/infrastructure"
+)
+
+func NewNSXTConfig(credentials *vsphere.Credentials, region *api.RegionSpec) *infrastructure.NSXTConfig {
+	return &infrastructure.NSXTConfig{
+		User:         credentials.NSXT_NetworkEngineer().Username,
+		Password:     credentials.NSXT_NetworkEngineer().Password,
+		Host:         region.NSXTHost,
+		InsecureFlag: region.NSXTInsecureSSL,
+		RemoteAuth:   region.NSXTRemoteAuth,
+	}
+}

--- a/pkg/vsphere/infrastructure/ensurer/ensurer.go
+++ b/pkg/vsphere/infrastructure/ensurer/ensurer.go
@@ -39,7 +39,14 @@ type ensurer struct {
 	// connector for simplified API (NSXT policy)
 	connector vapiclient.Connector
 	// nsxtClient is the NSX Manager client - based on go-vmware-nsxt SDK (Advanced API)
-	nsxtClient *nsxt.APIClient
+	nsxtClient     *nsxt.APIClient
+	shootNamespace string
+	gardenID       string
+}
+
+type ShootContext struct {
+	ShootNamespace string
+	GardenID       string
 }
 
 var _ task.EnsurerContext = &ensurer{}
@@ -64,7 +71,15 @@ func (e *ensurer) IsTryRecoverEnabled() bool {
 	return true
 }
 
-func NewNSXTInfrastructureEnsurer(logger logr.Logger, nsxtConfig *vinfra.NSXTConfig) (vinfra.NSXTInfrastructureEnsurer, error) {
+func (e *ensurer) ShootNamespace() string {
+	return e.shootNamespace
+}
+
+func (e *ensurer) GardenID() string {
+	return e.gardenID
+}
+
+func NewNSXTInfrastructureEnsurer(logger logr.Logger, nsxtConfig *vinfra.NSXTConfig, shootCtx *ShootContext) (vinfra.NSXTInfrastructureEnsurer, error) {
 	log.SetLogger(NewLogrBridge(logger))
 	connector, err := createConnectorNiceError(nsxtConfig)
 	if err != nil {
@@ -76,9 +91,11 @@ func NewNSXTInfrastructureEnsurer(logger logr.Logger, nsxtConfig *vinfra.NSXTCon
 	}
 
 	return &ensurer{
-		logger:     logger,
-		connector:  connector,
-		nsxtClient: nsxClient,
+		logger:         logger,
+		connector:      connector,
+		nsxtClient:     nsxClient,
+		shootNamespace: shootCtx.ShootNamespace,
+		gardenID:       shootCtx.GardenID,
 	}, nil
 }
 
@@ -238,4 +255,23 @@ func (e *ensurer) EnsureInfrastructureDeleted(spec *vinfra.NSXTInfraSpec, state 
 		}
 	}
 	return nil
+}
+
+func (e *ensurer) GetIPPoolTags(ipPoolName string) (map[string]string, error) {
+	id, _, err := task.LookupIPPoolIDByName(e, ipPoolName)
+	if err != nil {
+		return nil, err
+	}
+
+	client := infra.NewDefaultIpPoolsClient(e.Connector())
+	pool, err := client.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	tags := task.TagsToMap(pool.Tags)
+	return tags, nil
+}
+
+func (e *ensurer) CheckShootAuthorizationByTags(objectType, name string, tags map[string]string) error {
+	return task.CheckShootAuthorizationByTags(e.logger, objectType, name, e.shootNamespace, e.gardenID, tags)
 }

--- a/pkg/vsphere/infrastructure/infraspec.go
+++ b/pkg/vsphere/infrastructure/infraspec.go
@@ -27,6 +27,8 @@ import (
 const (
 	ScopeGarden = "garden"
 	ScopeShoot  = "shoot"
+	// ScopeAuthorizedShoots is the tag name used to annotate a NSX-T object with allowed shoot-names
+	ScopeAuthorizedShoots = "authorized-shoots"
 )
 
 func (s NSXTInfraSpec) FullClusterName() string {

--- a/pkg/vsphere/infrastructure/interface.go
+++ b/pkg/vsphere/infrastructure/interface.go
@@ -66,4 +66,8 @@ type NSXTInfrastructureEnsurer interface {
 	// EnsureInfrastructureDeleted ensures that all infrastructure objects are deleted
 	// It even trys to recover objects not recorded in the state before deleting them.
 	EnsureInfrastructureDeleted(spec *NSXTInfraSpec, state *api.NSXTInfraState) error
+	// GetIPPoolTags retrieves the tags of an IP pool
+	GetIPPoolTags(ipPoolName string) (map[string]string, error)
+	// CheckShootAuthorizationByTags checks if shoot namespace is allowed in the tags
+	CheckShootAuthorizationByTags(objectType, name string, tags map[string]string) error
 }

--- a/pkg/vsphere/infrastructure/task/helpers.go
+++ b/pkg/vsphere/infrastructure/task/helpers.go
@@ -153,3 +153,11 @@ func IdFromPath(path string) string {
 	id := parts[len(parts)-1]
 	return id
 }
+
+func TagsToMap(tags []model.Tag) map[string]string {
+	tagmap := map[string]string{}
+	for _, tag := range tags {
+		tagmap[*tag.Scope] = *tag.Tag
+	}
+	return tagmap
+}

--- a/pkg/vsphere/infrastructure/task/helpers_test.go
+++ b/pkg/vsphere/infrastructure/task/helpers_test.go
@@ -22,6 +22,8 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+
+	vinfra "github.com/gardener/gardener-extension-provider-vsphere/pkg/vsphere/infrastructure"
 )
 
 var _ = Describe("Helpers", func() {
@@ -106,6 +108,31 @@ var _ = Describe("Helpers", func() {
 	Describe("#IdFromPath", func() {
 		It("should extract id from path", func() {
 			Expect(IdFromPath("/infra/lb-services/60b86e75-41a0-474b-ab5d-ef46d3e1b25b")).To(Equal("60b86e75-41a0-474b-ab5d-ef46d3e1b25b"))
+		})
+	})
+})
+
+var _ = Describe("TaskHelper", func() {
+	Describe("#CheckShootAuthorizationByTags", func() {
+		It("should handle shoot authorization value correctly", func() {
+			tags := map[string]string{vinfra.ScopeAuthorizedShoots: "shoot--foo--bar1,shoot--myns--x*x", vinfra.ScopeGarden: "garden1"}
+			err := CheckShootAuthorizationByTags(nil, "IP pool", "mypool", "shoot--foo--bar1", "garden1", tags)
+			Expect(err).NotTo(HaveOccurred())
+			err = CheckShootAuthorizationByTags(nil, "IP pool", "mypool", "shoot--myns--xfoox", "garden1", tags)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = CheckShootAuthorizationByTags(nil, "IP pool", "mypool", "shoot--foo--bar1", "garden2", tags)
+			Expect(err).To(HaveOccurred())
+			err = CheckShootAuthorizationByTags(nil, "IP pool", "mypool", "shoot--foo--bar", "garden1", tags)
+			Expect(err).To(HaveOccurred())
+			err = CheckShootAuthorizationByTags(nil, "IP pool", "mypool", "shoot--foo--bar2", "garden1", tags)
+			Expect(err).To(HaveOccurred())
+			err = CheckShootAuthorizationByTags(nil, "IP pool", "mypool", "shoot--myns--foo", "garden1", tags)
+			Expect(err).To(HaveOccurred())
+			err = CheckShootAuthorizationByTags(nil, "IP pool", "mypool", "shoot--myns--xfoo", "garden1", tags)
+			Expect(err).To(HaveOccurred())
+			err = CheckShootAuthorizationByTags(nil, "IP pool", "mypool", "shoot--myns--xfooxz", "garden1", tags)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/pkg/vsphere/infrastructure/task/interface.go
+++ b/pkg/vsphere/infrastructure/task/interface.go
@@ -37,6 +37,10 @@ type EnsurerContext interface {
 	IsTryRecoverEnabled() bool
 	// GetNSXTVersion retrieves the NSX-T version
 	GetNSXTVersion() (*string, error)
+	// ShootNamespace returns the shoot namespace used for authorization
+	ShootNamespace() string
+	// GardenID returns the garden identity used for authorization
+	GardenID() string
 }
 
 type Task interface {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal
/platform vsphere

**What this PR does / why we need it**:
The `ControlPlaneConfig` in the shoot manifest allows to specify new `loadBalancerClasses` referencing a IP pool name not constrained by the cloud profile. For security reasons there is now a check if this IP pool is allowed for this shoot.
The IP pool must be tagged with a tag of scope `authorized-shoots`, the value contains a list of comma-separated technical shoot names, optionally with wildcards.
The same security check is also applied if the T1 gateway is specified in the `InfrastructureConfig` of the shoot spec.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
authorize shoot specific IP pools and T1 gateway by `authorized-shoots` tag
```
