### PR TITLE
check for orphan unmanaged LB service on deleting infrastructure

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -18,12 +18,8 @@ metadata:
   namespace: garden-dev
 type: Opaque
 data:
-  vsphereHost: base64(vsphere-host)
-  vsphereUsername: base64(vsphere-username)
   vspherePassword: base64(vsphere-password)
   vsphereInsecureSSL: base64("true"|"false")
-  nsxtHost: base64(NSX-T-host)
-  nsxtUsername: base64(NSX-T-username)
   nsxtPassword: base64(NSX-T-password)
   nsxtInsecureSSL: base64("true"|"false")
 ```
@@ -65,7 +61,8 @@ Then select `Copy path to clipboard` from the context menu of the tier-1 gateway
 (click on the three vertical dots on the left of the row). Do the same with the 
 corresponding load balancer at `Networking / Load balancing / Tab Load Balancers`
 For security reasons the referenced Tier-1 gateway in NSX-T must have a tag with scope `authorized-shoots` and its
-tag value consists of a comma-separated list of the allowed shoot names (optionally with wildcard `*`)
+tag value consists of a comma-separated list of the allowed shoot names in the format `shoot--<project>--<name>`
+(optionally with wildcard `*`). Additionally, it must have a tag with scope `garden` set to the garden ID.
 
 Example:
 
@@ -113,8 +110,9 @@ The specified names must be defined in the constraints section of the cloud prof
 If the list contains a load balancer named "default", it is used as the default load balancer.
 Otherwise the first one is also the default.
 If no classes are specified the default load balancer class is used as defined in the cloud profile constraints section.
-If the ipPoolName is overwritten, the IP pool object in NSX-T must have a tag with scope `authorized-shoots` and its
-tag value consists of a comma-separated list of the allowed shoot names (optionally with wildcard `*`)
+If the ipPoolName is overwritten, the corresponding IP pool object in NSX-T must have a tag with scope `authorized-shoots` and its
+tag value consists of a comma-separated list of the allowed shoot names in the format `shoot--<project>--<name>` 
+(optionally with wildcard `*`). Additionally, it must have a tag with scope `garden` set to the garden ID.
 
 The `loadBalancerSize` is optional and overwrites the default value specified in the cloud profile config.
 It must be one of the values `SMALL`, `MEDIUM`, or `LARGE`. `SMALL` can manage 10 service ports,

--- a/go.mod
+++ b/go.mod
@@ -50,8 +50,8 @@ replace (
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.17.9
 )
 
-// only needed for infra-cli
-replace k8s.io/cloud-provider-vsphere => github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200626142015-33b0a5766b2c
+// needed for infra-cli and load balancer cleanup
+replace k8s.io/cloud-provider-vsphere => github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200923145736-6d1acc9c5d28
 
 replace (
 	// these replacements are needed for the cloud-provider-vsphere

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20181220005116-f8e995905100/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
-github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200626142015-33b0a5766b2c h1:9T+Nspr9z8Xn3T5nzpJunIwQwu3lwXrtlQYVQAQQTL4=
-github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200626142015-33b0a5766b2c/go.mod h1:pUR2h4XvuzRIse3vjBSPHMmTCzJFitZP3fOLqZox5Y0=
+github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200923145736-6d1acc9c5d28 h1:zFa/3V9Hcg/WIiWAVh7xBJOAW8ZoOczELU+HjPOkJ+A=
+github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200923145736-6d1acc9c5d28/go.mod h1:pUR2h4XvuzRIse3vjBSPHMmTCzJFitZP3fOLqZox5Y0=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=

--- a/hack/update-github-templates.sh
+++ b/hack/update-github-templates.sh
@@ -26,6 +26,6 @@ for file in `find "$(dirname $0)"/../vendor/github.com/gardener/gardener/.github
     sed 's/to the Gardener project/for this extension/g' |\
     sed 's/to Gardener/to this extension/g' |\
     sed 's/- Gardener version:/- Gardener version (if relevant):\n- Extension version:/g' |\
-    sed 's/\/priority normal/\/priority normal\'$'\n''\/platform vmware/g' \
+    sed 's/\/priority normal/\/priority normal\'$'\n''\/platform vsphere/g' \
   > "$(dirname $0)/../.github/${file#*.github/}"
 done

--- a/pkg/cmd/infra-cli/loadbalancer/destroy.go
+++ b/pkg/cmd/infra-cli/loadbalancer/destroy.go
@@ -60,5 +60,5 @@ func DestroyAll(cfg *infrastructure.NSXTConfig, state *DestroyState) error {
 		return errors.Wrapf(err, "NewLBProvider failed")
 	}
 
-	return lbProvider.CleanupServices(state.ClusterName, map[types.NamespacedName]corev1.Service{})
+	return lbProvider.CleanupServices(state.ClusterName, map[types.NamespacedName]corev1.Service{}, true)
 }

--- a/pkg/vsphere/infrastructure/ensurer/ensurer.go
+++ b/pkg/vsphere/infrastructure/ensurer/ensurer.go
@@ -90,13 +90,16 @@ func NewNSXTInfrastructureEnsurer(logger logr.Logger, nsxtConfig *vinfra.NSXTCon
 		return nil, errors.Wrapf(err, "creating NSX-T client failed")
 	}
 
-	return &ensurer{
-		logger:         logger,
-		connector:      connector,
-		nsxtClient:     nsxClient,
-		shootNamespace: shootCtx.ShootNamespace,
-		gardenID:       shootCtx.GardenID,
-	}, nil
+	obj := &ensurer{
+		logger:     logger,
+		connector:  connector,
+		nsxtClient: nsxClient,
+	}
+	if shootCtx != nil {
+		obj.shootNamespace = shootCtx.ShootNamespace
+		obj.gardenID = shootCtx.GardenID
+	}
+	return obj, nil
 }
 
 func (e *ensurer) NewStateWithVersion(overwriteVersion *string) (*api.NSXTInfraState, error) {

--- a/vendor/k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer/cleanup.go
+++ b/vendor/k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer/cleanup.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -88,10 +89,10 @@ func (p *lbProvider) doCleanupStep(clusterName string, client clientcorev1.Servi
 		}
 	}
 
-	return p.CleanupServices(clusterName, services)
+	return p.CleanupServices(clusterName, services, false)
 }
 
-func (p *lbProvider) CleanupServices(clusterName string, validServices map[types.NamespacedName]corev1.Service) error {
+func (p *lbProvider) CleanupServices(clusterName string, validServices map[types.NamespacedName]corev1.Service, ensureLBServiceDeleted bool) error {
 	ipPoolIds := sets.NewString()
 	for _, name := range p.classes.GetClassNames() {
 		class := p.classes.GetClass(name)
@@ -162,6 +163,14 @@ func (p *lbProvider) CleanupServices(clusterName string, validServices map[types
 			if err != nil {
 				return err
 			}
+		}
+	}
+
+	// check for orphan unmanaged load balancer service if there are no virtual servers and flag ensureLBServiceDeleted == true
+	if len(lbs) == 0 && ensureLBServiceDeleted {
+		err = p.removeLoadBalancerServiceIfUnused(clusterName)
+		if err != nil && !isNotFoundError(err) {
+			return errors.Wrap(err, "removeLoadBalancerServiceIfUnused failed")
 		}
 	}
 	return nil

--- a/vendor/k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer/interface.go
+++ b/vendor/k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer/interface.go
@@ -31,7 +31,7 @@ import (
 type LBProvider interface {
 	cloudprovider.LoadBalancer
 	Initialize(clusterName string, client clientset.Interface, stop <-chan struct{})
-	CleanupServices(clusterName string, services map[types.NamespacedName]corev1.Service) error
+	CleanupServices(clusterName string, services map[types.NamespacedName]corev1.Service, ensureLBServiceDeleted bool) error
 }
 
 // NSXTAccess provides methods for dealing with NSX-T objects

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1001,7 +1001,7 @@ k8s.io/client-go/util/workqueue
 # k8s.io/cloud-provider v0.0.0 => k8s.io/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20190615005809-e8462b5b5dc2
 k8s.io/cloud-provider
 k8s.io/cloud-provider/node/helpers
-# k8s.io/cloud-provider-vsphere v1.1.0 => github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200626142015-33b0a5766b2c
+# k8s.io/cloud-provider-vsphere v1.1.0 => github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200923145736-6d1acc9c5d28
 ## explicit
 k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere
 k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer
@@ -1165,7 +1165,7 @@ sigs.k8s.io/yaml
 # k8s.io/component-base => k8s.io/component-base v0.17.9
 # k8s.io/helm => k8s.io/helm v2.13.1+incompatible
 # k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.17.9
-# k8s.io/cloud-provider-vsphere => github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200626142015-33b0a5766b2c
+# k8s.io/cloud-provider-vsphere => github.com/MartinWeindel/cloud-provider-vsphere v1.0.1-0.20200923145736-6d1acc9c5d28
 # k8s.io/cli-runtime => k8s.io/kubernetes/staging/src/k8s.io/cli-runtime v0.0.0-20190615005809-e8462b5b5dc2
 # k8s.io/cloud-provider => k8s.io/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20190615005809-e8462b5b5dc2
 # k8s.io/cluster-bootstrap => k8s.io/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20190615005809-e8462b5b5dc2


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal
/platform vsphere

**What this PR does / why we need it**:
On deleting the infrastructure it is also checked if there are any orphan load balancer object. Normally they should be already have been deleted by the cloud controller manager, but if ccm is terminate too early, there may be orphan objects.
This LB object cleanup missed the situation where all virtual servers have already been deleted by the CCM, but the load balancer service itself is still existing. This is addressed with this fix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
LB cleanup in infrastructure controller now also deletes an orphan NSXT-T LB service without any virtual servers.
```
