### PR TITLE
Fix "make test" on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,11 +133,11 @@ format:
 
 .PHONY: test
 test:
-	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/test.sh ./cmd/... ./pkg/...
+	@SKIP_FETCH_TOOLS=1 $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/test.sh ./cmd/... ./pkg/...
 
 .PHONY: test-cov
 test-cov:
-	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/test-cover.sh ./cmd/... ./pkg/...
+	@SKIP_FETCH_TOOLS=1 $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/test-cover.sh ./cmd/... ./pkg/...
 
 .PHONY: test-clean
 test-clean:

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gardener/gardener v1.12.3
 	github.com/gardener/machine-controller-manager v0.34.1
 	github.com/go-logr/logr v0.1.0
-	github.com/gobuffalo/packr/v2 v2.8.0
+	github.com/gobuffalo/packr/v2 v2.8.1
 	github.com/golang/mock v1.4.4-0.20200731163441-8734ec565a4d
 	github.com/google/uuid v1.1.1
 	github.com/onsi/ginkgo v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -346,8 +346,8 @@ github.com/gobuffalo/packd v1.0.0/go.mod h1:6VTc4htmJRFB7u1m/4LeMTWjFoYrUiBkU9Fd
 github.com/gobuffalo/packr v1.30.1 h1:hu1fuVR3fXEZR7rXNW3h8rqSML8EVAf6KNm0NKO/wKg=
 github.com/gobuffalo/packr v1.30.1/go.mod h1:ljMyFO2EcrnzsHsN99cvbq055Y9OhRrIaviy289eRuk=
 github.com/gobuffalo/packr/v2 v2.5.1/go.mod h1:8f9c96ITobJlPzI44jj+4tHnEKNt0xXWSVlXRN9X1Iw=
-github.com/gobuffalo/packr/v2 v2.8.0 h1:IULGd15bQL59ijXLxEvA5wlMxsmx/ZkQv9T282zNVIY=
-github.com/gobuffalo/packr/v2 v2.8.0/go.mod h1:PDk2k3vGevNE3SwVyVRgQCCXETC9SaONCNSXT1Q8M1g=
+github.com/gobuffalo/packr/v2 v2.8.1 h1:tkQpju6i3EtMXJ9uoF5GT6kB+LMTimDWD8Xvbz6zDVA=
+github.com/gobuffalo/packr/v2 v2.8.1/go.mod h1:c/PLlOuTU+p3SybaJATW3H6lX/iK7xEz5OeMf+NnJpg=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus v0.0.0-20181101234600-2ff6f7ffd60f/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
@@ -538,8 +538,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/karrick/godirwalk v1.10.12/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
-github.com/karrick/godirwalk v1.15.3 h1:0a2pXOgtB16CqIqXTiT7+K9L73f74n/aNQUnH6Ortew=
-github.com/karrick/godirwalk v1.15.3/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
+github.com/karrick/godirwalk v1.15.8 h1:7+rWAZPn9zuRxaIqqT8Ohs2Q2Ac0msBqwRdxNCr2VVs=
+github.com/karrick/godirwalk v1.15.8/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v0.0.0-20161130080628-0de1eaf82fa3/go.mod h1:jxZFDH7ILpTPQTk+E2s+z4CUas9lVNjIuKR4c5/zKgM=

--- a/vendor/github.com/gobuffalo/packr/v2/SHOULDERS.md
+++ b/vendor/github.com/gobuffalo/packr/v2/SHOULDERS.md
@@ -1,107 +1,17 @@
-# github.com/gobuffalo/packr/v2 Stands on the Shoulders of Giants
+# /Users/smichalak/dev/packr/v2 Stands on the Shoulders of Giants
 
-github.com/gobuffalo/packr/v2 does not try to reinvent the wheel! Instead, it uses the already great wheels developed by the Go community and puts them all together in the best way possible. Without these giants, this project would not be possible. Please make sure to check them out and thank them for all of their hard work.
+/Users/smichalak/dev/packr/v2 does not try to reinvent the wheel! Instead, it uses the already great wheels developed by the Go community and puts them all together in the best way possible. Without these giants, this project would not be possible. Please make sure to check them out and thank them for all of their hard work.
 
 Thank you to the following **GIANTS**:
 
-
-* [cloud.google.com/go](https://godoc.org/cloud.google.com/go)
-
-* [github.com/BurntSushi/toml](https://godoc.org/github.com/BurntSushi/toml)
-
-* [github.com/OneOfOne/xxhash](https://godoc.org/github.com/OneOfOne/xxhash)
-
-* [github.com/alecthomas/template](https://godoc.org/github.com/alecthomas/template)
-
-* [github.com/alecthomas/units](https://godoc.org/github.com/alecthomas/units)
-
-* [github.com/armon/consul-api](https://godoc.org/github.com/armon/consul-api)
-
-* [github.com/beorn7/perks](https://godoc.org/github.com/beorn7/perks)
-
-* [github.com/cespare/xxhash](https://godoc.org/github.com/cespare/xxhash)
-
-* [github.com/client9/misspell](https://godoc.org/github.com/client9/misspell)
-
-* [github.com/coreos/bbolt](https://godoc.org/github.com/coreos/bbolt)
-
-* [github.com/coreos/etcd](https://godoc.org/github.com/coreos/etcd)
-
-* [github.com/coreos/go-semver](https://godoc.org/github.com/coreos/go-semver)
-
-* [github.com/coreos/go-systemd](https://godoc.org/github.com/coreos/go-systemd)
-
-* [github.com/coreos/pkg](https://godoc.org/github.com/coreos/pkg)
-
-* [github.com/cpuguy83/go-md2man/v2](https://godoc.org/github.com/cpuguy83/go-md2man/v2)
-
-* [github.com/davecgh/go-spew](https://godoc.org/github.com/davecgh/go-spew)
-
-* [github.com/dgrijalva/jwt-go](https://godoc.org/github.com/dgrijalva/jwt-go)
-
-* [github.com/dgryski/go-sip13](https://godoc.org/github.com/dgryski/go-sip13)
-
-* [github.com/fsnotify/fsnotify](https://godoc.org/github.com/fsnotify/fsnotify)
-
-* [github.com/ghodss/yaml](https://godoc.org/github.com/ghodss/yaml)
-
-* [github.com/go-kit/kit](https://godoc.org/github.com/go-kit/kit)
-
-* [github.com/go-logfmt/logfmt](https://godoc.org/github.com/go-logfmt/logfmt)
-
-* [github.com/go-stack/stack](https://godoc.org/github.com/go-stack/stack)
 
 * [github.com/gobuffalo/logger](https://godoc.org/github.com/gobuffalo/logger)
 
 * [github.com/gobuffalo/packd](https://godoc.org/github.com/gobuffalo/packd)
 
-* [github.com/gogo/protobuf](https://godoc.org/github.com/gogo/protobuf)
-
-* [github.com/golang/glog](https://godoc.org/github.com/golang/glog)
-
-* [github.com/golang/groupcache](https://godoc.org/github.com/golang/groupcache)
-
-* [github.com/golang/mock](https://godoc.org/github.com/golang/mock)
-
-* [github.com/golang/protobuf](https://godoc.org/github.com/golang/protobuf)
-
-* [github.com/google/btree](https://godoc.org/github.com/google/btree)
-
-* [github.com/google/go-cmp](https://godoc.org/github.com/google/go-cmp)
-
-* [github.com/gorilla/websocket](https://godoc.org/github.com/gorilla/websocket)
-
-* [github.com/grpc-ecosystem/go-grpc-middleware](https://godoc.org/github.com/grpc-ecosystem/go-grpc-middleware)
-
-* [github.com/grpc-ecosystem/go-grpc-prometheus](https://godoc.org/github.com/grpc-ecosystem/go-grpc-prometheus)
-
-* [github.com/grpc-ecosystem/grpc-gateway](https://godoc.org/github.com/grpc-ecosystem/grpc-gateway)
-
-* [github.com/hashicorp/hcl](https://godoc.org/github.com/hashicorp/hcl)
-
-* [github.com/inconshreveable/mousetrap](https://godoc.org/github.com/inconshreveable/mousetrap)
-
-* [github.com/jonboulle/clockwork](https://godoc.org/github.com/jonboulle/clockwork)
-
-* [github.com/julienschmidt/httprouter](https://godoc.org/github.com/julienschmidt/httprouter)
-
 * [github.com/karrick/godirwalk](https://godoc.org/github.com/karrick/godirwalk)
 
-* [github.com/kisielk/errcheck](https://godoc.org/github.com/kisielk/errcheck)
-
-* [github.com/kisielk/gotool](https://godoc.org/github.com/kisielk/gotool)
-
 * [github.com/konsorten/go-windows-terminal-sequences](https://godoc.org/github.com/konsorten/go-windows-terminal-sequences)
-
-* [github.com/kr/logfmt](https://godoc.org/github.com/kr/logfmt)
-
-* [github.com/kr/pretty](https://godoc.org/github.com/kr/pretty)
-
-* [github.com/kr/pty](https://godoc.org/github.com/kr/pty)
-
-* [github.com/kr/text](https://godoc.org/github.com/kr/text)
-
-* [github.com/magiconair/properties](https://godoc.org/github.com/magiconair/properties)
 
 * [github.com/markbates/errx](https://godoc.org/github.com/markbates/errx)
 
@@ -109,114 +19,14 @@ Thank you to the following **GIANTS**:
 
 * [github.com/markbates/safe](https://godoc.org/github.com/markbates/safe)
 
-* [github.com/matttproud/golang_protobuf_extensions](https://godoc.org/github.com/matttproud/golang_protobuf_extensions)
-
-* [github.com/mitchellh/go-homedir](https://godoc.org/github.com/mitchellh/go-homedir)
-
-* [github.com/mitchellh/mapstructure](https://godoc.org/github.com/mitchellh/mapstructure)
-
-* [github.com/mwitkow/go-conntrack](https://godoc.org/github.com/mwitkow/go-conntrack)
-
-* [github.com/oklog/ulid](https://godoc.org/github.com/oklog/ulid)
-
-* [github.com/pelletier/go-toml](https://godoc.org/github.com/pelletier/go-toml)
-
-* [github.com/pkg/errors](https://godoc.org/github.com/pkg/errors)
-
-* [github.com/pmezard/go-difflib](https://godoc.org/github.com/pmezard/go-difflib)
-
-* [github.com/prometheus/client_golang](https://godoc.org/github.com/prometheus/client_golang)
-
-* [github.com/prometheus/client_model](https://godoc.org/github.com/prometheus/client_model)
-
-* [github.com/prometheus/common](https://godoc.org/github.com/prometheus/common)
-
-* [github.com/prometheus/procfs](https://godoc.org/github.com/prometheus/procfs)
-
-* [github.com/prometheus/tsdb](https://godoc.org/github.com/prometheus/tsdb)
-
-* [github.com/rogpeppe/fastuuid](https://godoc.org/github.com/rogpeppe/fastuuid)
-
 * [github.com/rogpeppe/go-internal](https://godoc.org/github.com/rogpeppe/go-internal)
-
-* [github.com/russross/blackfriday/v2](https://godoc.org/github.com/russross/blackfriday/v2)
-
-* [github.com/shurcooL/sanitized_anchor_name](https://godoc.org/github.com/shurcooL/sanitized_anchor_name)
 
 * [github.com/sirupsen/logrus](https://godoc.org/github.com/sirupsen/logrus)
 
-* [github.com/soheilhy/cmux](https://godoc.org/github.com/soheilhy/cmux)
-
-* [github.com/spaolacci/murmur3](https://godoc.org/github.com/spaolacci/murmur3)
-
-* [github.com/spf13/afero](https://godoc.org/github.com/spf13/afero)
-
-* [github.com/spf13/cast](https://godoc.org/github.com/spf13/cast)
-
 * [github.com/spf13/cobra](https://godoc.org/github.com/spf13/cobra)
-
-* [github.com/spf13/jwalterweatherman](https://godoc.org/github.com/spf13/jwalterweatherman)
-
-* [github.com/spf13/pflag](https://godoc.org/github.com/spf13/pflag)
-
-* [github.com/spf13/viper](https://godoc.org/github.com/spf13/viper)
-
-* [github.com/stretchr/objx](https://godoc.org/github.com/stretchr/objx)
 
 * [github.com/stretchr/testify](https://godoc.org/github.com/stretchr/testify)
 
-* [github.com/tmc/grpc-websocket-proxy](https://godoc.org/github.com/tmc/grpc-websocket-proxy)
-
-* [github.com/ugorji/go](https://godoc.org/github.com/ugorji/go)
-
-* [github.com/xiang90/probing](https://godoc.org/github.com/xiang90/probing)
-
-* [github.com/xordataexchange/crypt](https://godoc.org/github.com/xordataexchange/crypt)
-
-* [go.etcd.io/bbolt](https://godoc.org/go.etcd.io/bbolt)
-
-* [go.uber.org/atomic](https://godoc.org/go.uber.org/atomic)
-
-* [go.uber.org/multierr](https://godoc.org/go.uber.org/multierr)
-
-* [go.uber.org/zap](https://godoc.org/go.uber.org/zap)
-
-* [golang.org/x/crypto](https://godoc.org/golang.org/x/crypto)
-
-* [golang.org/x/lint](https://godoc.org/golang.org/x/lint)
-
-* [golang.org/x/mod](https://godoc.org/golang.org/x/mod)
-
-* [golang.org/x/net](https://godoc.org/golang.org/x/net)
-
-* [golang.org/x/oauth2](https://godoc.org/golang.org/x/oauth2)
-
 * [golang.org/x/sync](https://godoc.org/golang.org/x/sync)
 
-* [golang.org/x/sys](https://godoc.org/golang.org/x/sys)
-
-* [golang.org/x/text](https://godoc.org/golang.org/x/text)
-
-* [golang.org/x/time](https://godoc.org/golang.org/x/time)
-
 * [golang.org/x/tools](https://godoc.org/golang.org/x/tools)
-
-* [golang.org/x/xerrors](https://godoc.org/golang.org/x/xerrors)
-
-* [google.golang.org/appengine](https://godoc.org/google.golang.org/appengine)
-
-* [google.golang.org/genproto](https://godoc.org/google.golang.org/genproto)
-
-* [google.golang.org/grpc](https://godoc.org/google.golang.org/grpc)
-
-* [gopkg.in/alecthomas/kingpin.v2](https://godoc.org/gopkg.in/alecthomas/kingpin.v2)
-
-* [gopkg.in/check.v1](https://godoc.org/gopkg.in/check.v1)
-
-* [gopkg.in/errgo.v2](https://godoc.org/gopkg.in/errgo.v2)
-
-* [gopkg.in/resty.v1](https://godoc.org/gopkg.in/resty.v1)
-
-* [gopkg.in/yaml.v2](https://godoc.org/gopkg.in/yaml.v2)
-
-* [honnef.co/go/tools](https://godoc.org/honnef.co/go/tools)

--- a/vendor/github.com/gobuffalo/packr/v2/go.mod
+++ b/vendor/github.com/gobuffalo/packr/v2/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/gobuffalo/logger v1.0.3
 	github.com/gobuffalo/packd v1.0.0
-	github.com/karrick/godirwalk v1.15.3
+	github.com/karrick/godirwalk v1.15.8
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/markbates/errx v1.1.0
 	github.com/markbates/oncer v1.0.0

--- a/vendor/github.com/gobuffalo/packr/v2/go.sum
+++ b/vendor/github.com/gobuffalo/packr/v2/go.sum
@@ -47,8 +47,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/karrick/godirwalk v1.15.3 h1:0a2pXOgtB16CqIqXTiT7+K9L73f74n/aNQUnH6Ortew=
-github.com/karrick/godirwalk v1.15.3/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
+github.com/karrick/godirwalk v1.15.8 h1:7+rWAZPn9zuRxaIqqT8Ohs2Q2Ac0msBqwRdxNCr2VVs=
+github.com/karrick/godirwalk v1.15.8/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/vendor/github.com/gobuffalo/packr/v2/version.go
+++ b/vendor/github.com/gobuffalo/packr/v2/version.go
@@ -1,4 +1,4 @@
 package packr
 
 // Version of Packr
-const Version = "v2.8.0"
+const Version = "v2.8.1"

--- a/vendor/github.com/karrick/godirwalk/bench.sh
+++ b/vendor/github.com/karrick/godirwalk/bench.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# for version in v1.9.1 v1.10.0 v1.10.3 v1.10.12 v1.11.2 v1.11.3 v1.12.0 v1.13.1 v1.14.0 v1.14.1 ; do
+for version in v1.10.12 v1.14.1 v1.15.2 ; do
+    echo "### $version" > $version.txt
+    git checkout -- go.mod && git checkout $version && go test -run=NONE -bench=Benchmark2 >> $version.txt || exit 1
+done

--- a/vendor/github.com/karrick/godirwalk/readdir_unix.go
+++ b/vendor/github.com/karrick/godirwalk/readdir_unix.go
@@ -31,11 +31,15 @@ func readDirents(osDirname string, scratchBuffer []byte) ([]*Dirent, error) {
 		scratchBuffer = newScratchBuffer()
 	}
 
+	var sde syscall.Dirent
 	for {
 		if len(workBuffer) == 0 {
 			n, err := syscall.ReadDirent(fd, scratchBuffer)
 			// n, err := unix.ReadDirent(fd, scratchBuffer)
 			if err != nil {
+				if err == syscall.EINTR /* || err == unix.EINTR */ {
+					continue
+				}
 				_ = dh.Close()
 				return nil, err
 			}
@@ -48,14 +52,14 @@ func readDirents(osDirname string, scratchBuffer []byte) ([]*Dirent, error) {
 			workBuffer = scratchBuffer[:n] // trim work buffer to number of bytes read
 		}
 
-		sde := (*syscall.Dirent)(unsafe.Pointer(&workBuffer[0])) // point entry to first syscall.Dirent in buffer
-		workBuffer = workBuffer[reclen(sde):]                    // advance buffer for next iteration through loop
+		copy((*[unsafe.Sizeof(syscall.Dirent{})]byte)(unsafe.Pointer(&sde))[:], workBuffer)
+		workBuffer = workBuffer[reclen(&sde):] // advance buffer for next iteration through loop
 
-		if inoFromDirent(sde) == 0 {
+		if inoFromDirent(&sde) == 0 {
 			continue // inode set to 0 indicates an entry that was marked as deleted
 		}
 
-		nameSlice := nameFromDirent(sde)
+		nameSlice := nameFromDirent(&sde)
 		nameLength := len(nameSlice)
 
 		if nameLength == 0 || (nameSlice[0] == '.' && (nameLength == 1 || (nameLength == 2 && nameSlice[1] == '.'))) {
@@ -63,7 +67,7 @@ func readDirents(osDirname string, scratchBuffer []byte) ([]*Dirent, error) {
 		}
 
 		childName := string(nameSlice)
-		mt, err := modeTypeFromDirent(sde, osDirname, childName)
+		mt, err := modeTypeFromDirent(&sde, osDirname, childName)
 		if err != nil {
 			_ = dh.Close()
 			return nil, err
@@ -92,6 +96,9 @@ func readDirnames(osDirname string, scratchBuffer []byte) ([]string, error) {
 			n, err := syscall.ReadDirent(fd, scratchBuffer)
 			// n, err := unix.ReadDirent(fd, scratchBuffer)
 			if err != nil {
+				if err == syscall.EINTR /* || err == unix.EINTR */ {
+					continue
+				}
 				_ = dh.Close()
 				return nil, err
 			}
@@ -104,9 +111,9 @@ func readDirnames(osDirname string, scratchBuffer []byte) ([]string, error) {
 			workBuffer = scratchBuffer[:n] // trim work buffer to number of bytes read
 		}
 
-		// Handle first entry in the work buffer.
 		sde = (*syscall.Dirent)(unsafe.Pointer(&workBuffer[0])) // point entry to first syscall.Dirent in buffer
-		workBuffer = workBuffer[reclen(sde):]                   // advance buffer for next iteration through loop
+		// Handle first entry in the work buffer.
+		workBuffer = workBuffer[reclen(sde):] // advance buffer for next iteration through loop
 
 		if inoFromDirent(sde) == 0 {
 			continue // inode set to 0 indicates an entry that was marked as deleted

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -206,7 +206,7 @@ github.com/gobuffalo/logger
 # github.com/gobuffalo/packd v1.0.0
 github.com/gobuffalo/packd
 github.com/gobuffalo/packd/internal/takeon/github.com/markbates/errx
-# github.com/gobuffalo/packr/v2 v2.8.0
+# github.com/gobuffalo/packr/v2 v2.8.1
 ## explicit
 github.com/gobuffalo/packr/v2
 github.com/gobuffalo/packr/v2/file
@@ -302,7 +302,7 @@ github.com/imdario/mergo
 github.com/inconshreveable/mousetrap
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
-# github.com/karrick/godirwalk v1.15.3
+# github.com/karrick/godirwalk v1.15.8
 github.com/karrick/godirwalk
 # github.com/konsorten/go-windows-terminal-sequences v1.0.3
 github.com/konsorten/go-windows-terminal-sequences


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug
/priority normal
/platform vsphere

**What this PR does / why we need it**:
Currently `make test` fails on macOS - see https://github.com/gardener/gardener-extension-provider-gcp/pull/183#issuecomment-706756203. The issue is fixed on `github.com/gobuffalo/packr/v2` side with https://github.com/gobuffalo/packr/pull/284.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
An issue causing `make test` to fail on macOS is now fixed.
```
