### PR TITLE
fix volumeBindingMode and indendation of availability zones labels in cloud-provider-config

### DIFF
--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
@@ -31,10 +31,10 @@ data:
     {{- if (or .Values.labelRegion .Values.labelZone) }}
     labels:
     {{- if .Values.labelRegion }}
-    region: "{{ .Values.labelRegion }}"
+      region: "{{ .Values.labelRegion }}"
     {{- end }}
     {{- if .Values.labelZone }}
-    zone: "{{ .Values.labelZone }}"
+      zone: "{{ .Values.labelZone }}"
     {{- end }}
     {{- end }}
 

--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -7,6 +7,6 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
     resources.gardener.cloud/delete-on-invalid-update: "true"
 provisioner: csi.vsphere.vmware.com
-volumeBindingMode: WaitForFirstConsumer
+volumeBindingMode: {{ .Values.volumeBindingMode }}
 parameters:
   storagePolicyName: "{{ .Values.storagePolicyName }}"

--- a/charts/internal/shoot-storageclasses/values.yaml
+++ b/charts/internal/shoot-storageclasses/values.yaml
@@ -1,1 +1,2 @@
 storagePolicyName: vSAN Default Storage Policy
+volumeBindingMode: Immediate

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -348,8 +348,15 @@ func (vp *valuesProvider) GetStorageClassesChartValues(
 		return nil, err
 	}
 
+	volumeBindingMode := "Immediate"
+	if cloudProfileConfig.FailureDomainLabels != nil {
+		// can only be used if topology tags are set
+		volumeBindingMode = "WaitForFirstConsumer"
+	}
+
 	return map[string]interface{}{
 		"storagePolicyName": cloudProfileConfig.DefaultClassStoragePolicyName,
+		"volumeBindingMode": volumeBindingMode,
 	}, nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority normal
/platform vsphere

**What this PR does / why we need it**:
The volumeBindingMode `WaitForFirstConsumer` must only be used for the shoot storageclass if availability tags are set in vSphere.
Additionally the indendation of the labels fields is fixed in the cloud-provider-config.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
