### PR TITLE
shoot default storageclass: enable allowVolumeExpansion if resizer is available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ############# builder
-FROM golang:1.15.3 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.15.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-vsphere
 COPY . .
 RUN make install
 
 ############# base
-FROM alpine:3.11.3 AS base
+FROM alpine:3.12.1 AS base
 
 ############# gardener-extension-provider-vsphere
 FROM base AS gardener-extension-provider-vsphere

--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -8,5 +8,6 @@ metadata:
     resources.gardener.cloud/delete-on-invalid-update: "true"
 provisioner: csi.vsphere.vmware.com
 volumeBindingMode: {{ .Values.volumeBindingMode }}
+allowVolumeExpansion: {{ .Values.allowVolumeExpansion }}
 parameters:
   storagePolicyName: "{{ .Values.storagePolicyName }}"

--- a/charts/internal/shoot-storageclasses/values.yaml
+++ b/charts/internal/shoot-storageclasses/values.yaml
@@ -1,2 +1,3 @@
 storagePolicyName: vSAN Default Storage Policy
 volumeBindingMode: Immediate
+allowVolumeExpansion: false

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -353,10 +353,12 @@ func (vp *valuesProvider) GetStorageClassesChartValues(
 		// can only be used if topology tags are set
 		volumeBindingMode = "WaitForFirstConsumer"
 	}
+	allowVolumeExpansion := cloudProfileConfig.CSIResizerDisabled == nil || !*cloudProfileConfig.CSIResizerDisabled
 
 	return map[string]interface{}{
-		"storagePolicyName": cloudProfileConfig.DefaultClassStoragePolicyName,
-		"volumeBindingMode": volumeBindingMode,
+		"storagePolicyName":    cloudProfileConfig.DefaultClassStoragePolicyName,
+		"volumeBindingMode":    volumeBindingMode,
+		"allowVolumeExpansion": allowVolumeExpansion,
 	}, nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal
/platform vsphere

**What this PR does / why we need it**:
Enable the flag `allowVolumeExpansion` for the default shoot `StorageClass` if CSI resizer is available

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
shoot default storageclass: enable allowVolumeExpansion if resizer is available
```
