### PR TITLE
Add Worker and ControlPlane CRD to examples

### DIFF
--- a/example/20-crd-controlplane.yaml
+++ b/example/20-crd-controlplane.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: controlplanes.extensions.gardener.cloud
+spec:
+  group: extensions.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: controlplanes
+    singular: controlplane
+    kind: ControlPlane
+    shortNames:
+    - cp
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The control plane type.
+    JSONPath: .spec.type
+  - name: State
+    type: string
+    JSONPath: .status.lastOperation.state
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}

--- a/example/20-crd-worker.yaml
+++ b/example/20-crd-worker.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: workers.extensions.gardener.cloud
+spec:
+  group: extensions.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: workers
+    singular: worker
+    kind: Worker
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The worker type.
+    JSONPath: .spec.type
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}


### PR DESCRIPTION
This extension is serving Worker and ControlPlane resources and dependent on having those defined in the cluster on start, so it should ship with the CRD definitions.

**Release note**:

```NONE

```
