### PR TITLE
use secret for cloud-provider-config

### DIFF
--- a/charts/internal/cloud-provider-config/templates/_cloud-provider-config.tpl
+++ b/charts/internal/cloud-provider-config/templates/_cloud-provider-config.tpl
@@ -1,0 +1,74 @@
+{{- define "cloud-provider-config" -}}
+global:
+  soapRoundtripCount: {{ .Values.soapRoundtripCount }}
+  ipFamily:
+  - ipv4
+  {{- if .Values.caFile }}
+  caFile: "{{ .Values.caFile }}"
+  {{- end }}
+  {{- if .Values.thumbprint }}
+  thumbprint: "{{ .Values.thumbprint }}"
+  {{- end }}
+
+vcenter:
+  {{ .Values.serverName }}:
+    server: {{ .Values.serverName }}
+    port: {{ .Values.serverPort }}
+    datacenters:
+    {{- range .Values.datacenters }}
+    - {{ . | quote }}
+    {{- end }}
+    user: "{{ .Values.username }}"
+    password: "{{ .Values.password }}"
+    insecureFlag: {{ .Values.insecureFlag }}
+
+{{- if (or .Values.labelRegion .Values.labelZone) }}
+labels:
+{{- if .Values.labelRegion }}
+  region: "{{ .Values.labelRegion }}"
+{{- end }}
+{{- if .Values.labelZone }}
+  zone: "{{ .Values.labelZone }}"
+{{- end }}
+{{- end }}
+
+loadBalancer:
+  {{- if .Values.loadbalancer.lbServiceId }}
+  lbServiceId: "{{ .Values.loadbalancer.lbServiceId }}"
+  {{- end }}
+  ipPoolName: "{{ .Values.loadbalancer.ipPoolName }}"
+  size: {{ .Values.loadbalancer.size }}
+  tier1GatewayPath: "{{ .Values.loadbalancer.tier1GatewayPath }}"
+  tcpAppProfileName: "{{ .Values.loadbalancer.tcpAppProfileName }}"
+  udpAppProfileName: "{{ .Values.loadbalancer.udpAppProfileName }}"
+  tags:
+  {{- range $k, $v := .Values.loadbalancer.tags }}
+    {{ $k }}: {{ $v | quote }}
+  {{- end }}
+
+loadBalancerClass:
+{{- range $i, $class := .Values.loadbalancer.classes }}
+  {{ $class.name }}:
+    name: {{ $class.name }}
+    {{- if $class.ipPoolName }}
+    ipPoolName: "{{ $class.ipPoolName }}"
+    {{- end }}
+    {{- if $class.tcpAppProfileName }}
+    tcpAppProfileName: "{{ $class.tcpAppProfileName }}"
+    {{- end }}
+    {{- if $class.udpAppProfileName }}
+    udpAppProfileName: "{{ $class.udpAppProfileName }}"
+    {{- end }}
+{{- end }}
+
+nsxt:
+  user: "{{ .Values.nsxt.username }}"
+  password: "{{ .Values.nsxt.password }}"
+  {{- if .Values.nsxt.usernameNE }}
+  userNE: "{{ .Values.nsxt.usernameNE }}"
+  passwordNE: "{{ .Values.nsxt.passwordNE }}"
+  {{- end }}
+  host: "{{ .Values.nsxt.host }}"
+  insecureFlag: {{ .Values.nsxt.insecureFlag }}
+  remoteAuth: {{ .Values.nsxt.remoteAuth }}
+{{- end -}}

--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
@@ -1,79 +1,8 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: cloud-provider-config
   namespace: {{ .Release.Namespace }}
+type: Opaque
 data:
-  cloudprovider.conf: |
-    global:
-      soapRoundtripCount: {{ .Values.soapRoundtripCount }}
-      ipFamily:
-      - ipv4
-      {{- if .Values.caFile }}
-      caFile: "{{ .Values.caFile }}"
-      {{- end }}
-      {{- if .Values.thumbprint }}
-      thumbprint: "{{ .Values.thumbprint }}"
-      {{- end }}
-
-    vcenter:
-      {{ .Values.serverName }}:
-        server: {{ .Values.serverName }}
-        port: {{ .Values.serverPort }}
-        datacenters:
-        {{- range .Values.datacenters }}
-        - {{ . | quote }}
-        {{- end }}
-        user: "{{ .Values.username }}"
-        password: "{{ .Values.password }}"
-        insecureFlag: {{ .Values.insecureFlag }}
-
-    {{- if (or .Values.labelRegion .Values.labelZone) }}
-    labels:
-    {{- if .Values.labelRegion }}
-      region: "{{ .Values.labelRegion }}"
-    {{- end }}
-    {{- if .Values.labelZone }}
-      zone: "{{ .Values.labelZone }}"
-    {{- end }}
-    {{- end }}
-
-    loadBalancer:
-      {{- if .Values.loadbalancer.lbServiceId }}
-      lbServiceId: "{{ .Values.loadbalancer.lbServiceId }}"
-      {{- end }}
-      ipPoolName: "{{ .Values.loadbalancer.ipPoolName }}"
-      size: {{ .Values.loadbalancer.size }}
-      tier1GatewayPath: "{{ .Values.loadbalancer.tier1GatewayPath }}"
-      tcpAppProfileName: "{{ .Values.loadbalancer.tcpAppProfileName }}"
-      udpAppProfileName: "{{ .Values.loadbalancer.udpAppProfileName }}"
-      tags:
-      {{- range $k, $v := .Values.loadbalancer.tags }}
-        {{ $k }}: {{ $v | quote }}
-      {{- end }}
-
-    loadBalancerClass:
-    {{- range $i, $class := .Values.loadbalancer.classes }}
-      {{ $class.name }}:
-        name: {{ $class.name }}
-        {{- if $class.ipPoolName }}
-        ipPoolName: "{{ $class.ipPoolName }}"
-        {{- end }}
-        {{- if $class.tcpAppProfileName }}
-        tcpAppProfileName: "{{ $class.tcpAppProfileName }}"
-        {{- end }}
-        {{- if $class.udpAppProfileName }}
-        udpAppProfileName: "{{ $class.udpAppProfileName }}"
-        {{- end }}
-    {{- end }}
-
-    nsxt:
-      user: "{{ .Values.nsxt.username }}"
-      password: "{{ .Values.nsxt.password }}"
-      {{- if .Values.nsxt.usernameNE }}
-      userNE: "{{ .Values.nsxt.usernameNE }}"
-      passwordNE: "{{ .Values.nsxt.passwordNE }}"
-      {{- end }}
-      host: "{{ .Values.nsxt.host }}"
-      insecureFlag: {{ .Values.nsxt.insecureFlag }}
-      remoteAuth: {{ .Values.nsxt.remoteAuth }}
+  cloudprovider.conf: {{ include "cloud-provider-config" . | b64enc }}

--- a/charts/internal/seed-controlplane/charts/vsphere-cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/vsphere-cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -100,5 +100,5 @@ spec:
         secret:
           secretName: cloud-controller-manager-server
       - name: cloud-provider-config
-        configMap:
-          name: cloud-provider-config
+        secret:
+          secretName: cloud-provider-config

--- a/pkg/controller/controlplane/add.go
+++ b/pkg/controller/controlplane/add.go
@@ -51,7 +51,7 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return controlplane.Add(mgr, controlplane.AddArgs{
 		Actuator: genericactuator.NewActuator(vsphere.Name, controlPlaneSecrets, nil, configChart, controlPlaneChart, controlPlaneShootChart,
 			storageClassChart, nil, NewValuesProvider(logger, opts.GardenId), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
-			imagevector.ImageVector(), vsphere.CloudProviderConfig, nil, mgr.GetWebhookServer().Port, logger),
+			imagevector.ImageVector(), "", nil, mgr.GetWebhookServer().Port, logger),
 		ControllerOptions: opts.Controller,
 		Predicates:        controlplane.DefaultPredicates(opts.IgnoreOperationAnnotation),
 		Type:              vsphere.Type,

--- a/pkg/controller/controlplane/clean_old_resources.go
+++ b/pkg/controller/controlplane/clean_old_resources.go
@@ -20,6 +20,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener-extension-provider-vsphere/pkg/vsphere"
 )
 
 func (vp *valuesProvider) deleteCCMMonitoringConfig(ctx context.Context, ns string) error {
@@ -27,6 +29,18 @@ func (vp *valuesProvider) deleteCCMMonitoringConfig(ctx context.Context, ns stri
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
 			Name:      "cloud-controller-manager-monitoring-config",
+		},
+	}
+
+	return client.IgnoreNotFound(vp.Client().Delete(ctx, cm))
+}
+
+// TODO: Remove this in a future version again.
+func (vp *valuesProvider) deleteLegacyCloudProviderConfigMap(ctx context.Context, ns string) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      vsphere.CloudProviderConfig,
 		},
 	}
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -326,6 +326,11 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 		return nil, err
 	}
 
+	// TODO: Remove this code in a future version again.
+	if err := vp.deleteLegacyCloudProviderConfigMap(ctx, cp.Namespace); err != nil {
+		return nil, err
+	}
+
 	// Get control plane chart values
 	return vp.getControlPlaneChartValues(cpConfig, cp, cluster, credentials, checksums, scaledDown)
 }

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -249,6 +249,14 @@ insecure-flag = "true"
 			},
 		}
 
+		// TODO remove legacyCloudProviderConfigMap in next version
+		legacyCloudProviderConfigMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      vsphere.CloudProviderConfig,
+			},
+		}
+
 		checksums = map[string]string{
 			v1beta1constants.SecretNameCloudProvider: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
 			vsphere.CloudProviderConfig:              "08a7bc7fe8f59b055f173145e211760a83f02cf89635cef26ebb351378635606",
@@ -401,6 +409,7 @@ insecure-flag = "true"
 		It("should return correct control plane chart values", func() {
 			vp := prepareValueProvider(true)
 			c.EXPECT().Delete(context.TODO(), ccmMonitoringConfigmap).DoAndReturn(clientDeleteSuccess())
+			c.EXPECT().Delete(context.TODO(), legacyCloudProviderConfigMap).DoAndReturn(clientDeleteSuccess())
 
 			// Call GetControlPlaneChartValues method and check the result
 			values, err := vp.GetControlPlaneChartValues(context.TODO(), cp, cluster, checksums, false)

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -209,6 +209,17 @@ var _ = Describe("ValuesProvider", func() {
 			},
 		}
 
+		cpcSecretKey = client.ObjectKey{Namespace: namespace, Name: vsphere.CloudProviderConfig}
+		cpcSecret    = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vsphere.CloudProviderConfig,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"cloudprovider.conf": []byte{}},
+		}
+
 		csiSecretKey = client.ObjectKey{Namespace: namespace, Name: vsphere.SecretCSIVsphereConfig}
 		csiSecret    = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -295,7 +306,7 @@ insecure-flag = "true"
 					"checksum/secret-" + vsphere.CloudControllerManagerName:       "3d791b164a808638da9a8df03924be2a41e34cd664e42231c00fe369e3588272",
 					"checksum/secret-" + vsphere.CloudControllerManagerServerName: "6dff2a2e6f14444b66d8e4a351c049f7e89ee24ba3eaab95dbec40ba6bdebb52",
 					"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
-					"checksum/configmap-" + vsphere.CloudProviderConfig:           "08a7bc7fe8f59b055f173145e211760a83f02cf89635cef26ebb351378635606",
+					"checksum/secret-" + vsphere.CloudProviderConfig:              "67234961d8244bf8bd661e1d165036e691b6570a8981a09942df2314644a8b97",
 				},
 				"podLabels": map[string]interface{}{
 					"maintenance.gardener.cloud/restart": "true",
@@ -346,10 +357,11 @@ insecure-flag = "true"
 
 		logger = log.Log.WithName("test")
 
-		prepareValueProvider = func(csi bool) genericactuator.ValuesProvider {
+		prepareValueProvider = func(cpcAndCsi bool) genericactuator.ValuesProvider {
 			// Create mock client
 			c = mockclient.NewMockClient(ctrl)
-			if csi {
+			if cpcAndCsi {
+				c.EXPECT().Get(context.TODO(), cpcSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpcSecret))
 				c.EXPECT().Get(context.TODO(), csiSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(csiSecret))
 			}
 			c.EXPECT().Get(context.TODO(), cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	namespace                  = "test"
-	cloudProviderConfigContent = "[Global]\nsoap-roundtrip-count = \"1\"\nip-family = \"ipv4\"\n"
+	cloudProviderConfigContent = "global:\n  soap-roundtrip-count: \"1\"\n  ip-family: \"ipv4\"\n"
 )
 
 func TestController(t *testing.T) {
@@ -54,14 +54,14 @@ var _ = Describe("Ensurer", func() {
 
 		dummyContext = gcontext.NewGardenContext(nil, nil)
 
-		cmKey = client.ObjectKey{Namespace: namespace, Name: vsphere.CloudProviderConfig}
-		cm    = &corev1.ConfigMap{
+		secretObjectKey = client.ObjectKey{Namespace: namespace, Name: vsphere.CloudProviderConfig}
+		secret          = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: vsphere.CloudProviderConfig},
-			Data:       map[string]string{"abc": "xyz", vsphere.CloudProviderConfigMapKey: cloudProviderConfigContent},
+			Data:       map[string][]byte{"abc": []byte("xyz"), vsphere.CloudProviderConfigMapKey: []byte(cloudProviderConfigContent)},
 		}
 
 		annotations = map[string]string{
-			"checksum/configmap-" + vsphere.CloudProviderConfig: "65ce1f311ffd66c6a66c6086910ed7b5443cd495cb601a21de1d685f8c146a2c",
+			"checksum/secret-" + vsphere.CloudProviderConfig: "77666f4cd38d72a694c95f07bd98683012f5762a60e783d0b89863a3515fcf2e",
 		}
 
 		kubeControllerManagerLabels = map[string]string{
@@ -99,7 +99,7 @@ var _ = Describe("Ensurer", func() {
 
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+			client.EXPECT().Get(context.TODO(), secretObjectKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
@@ -137,7 +137,7 @@ var _ = Describe("Ensurer", func() {
 
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+			client.EXPECT().Get(context.TODO(), secretObjectKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
@@ -177,7 +177,7 @@ var _ = Describe("Ensurer", func() {
 
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+			client.EXPECT().Get(context.TODO(), secretObjectKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
 			// Create ensurer
 			ensurer := NewEnsurer(logger)
@@ -226,7 +226,7 @@ var _ = Describe("Ensurer", func() {
 
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
-			client.EXPECT().Get(context.TODO(), cmKey, &corev1.ConfigMap{}).DoAndReturn(clientGet(cm))
+			client.EXPECT().Get(context.TODO(), secretObjectKey, &corev1.Secret{}).DoAndReturn(clientGet(secret))
 
 			// Create ensurer
 			ensurer := NewEnsurer(logger)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area security
/kind task
/priority normal
/platform vsphere

**What this PR does / why we need it**:
The cloudprovider config for the cloud controller manager is now stored in a secret instead of a configmap as it contains user credentials.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Cloud provider config for the cloud controller manager is now stored in a Secret instead of a ConfigMap.
```
