### PR TITLE
updated image of mcm-provider-vsphere to v0.9.0

### DIFF
--- a/charts/gardener-extension-validator-vsphere/charts/runtime/templates/poddisruptionbudget.yaml
+++ b/charts/gardener-extension-validator-vsphere/charts/runtime/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if gt (int .Values.global.replicaCount) 1 }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "labels" . | indent 4 }}
+spec:
+  maxUnavailable: {{ sub (int .Values.global.replicaCount) 1 }}
+  selector:
+    matchLabels:
+{{ include "labels" . | indent 6 }}
+{{- end }}

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -31,7 +31,7 @@ images:
 - name: machine-controller-manager-provider-vsphere
   sourceRepository: github.com/gardener/machine-controller-manager-provider-vsphere
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-vsphere
-  tag: "v0.8.0"
+  tag: "v0.9.0"
 - name: vsphere-csi-driver-controller
   #sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   #repository: gcr.io/cloud-provider-vsphere/csi/release/driver

--- a/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
+++ b/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
@@ -60,3 +60,10 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/gardener/etcd-druid v0.3.0
 	github.com/gardener/gardener v1.15.1-0.20210115062544-6dc08568692a
-	github.com/gardener/machine-controller-manager v0.35.0
+	github.com/gardener/machine-controller-manager v0.37.0
 	github.com/go-logr/logr v0.3.0
 	github.com/gobuffalo/packr/v2 v2.8.1
 	github.com/golang/mock v1.4.4-0.20200731163441-8734ec565a4d

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,7 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7/go.mod h1:LWMyo4iOLWXHGdBki7NIht1kHru/0wM179h+d3g8ATM=
 github.com/aws/aws-sdk-go v1.13.54/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
 github.com/aws/aws-sdk-go v1.19.41/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.23.13/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.28.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/bazelbuild/bazel-gazelle v0.18.2/go.mod h1:D0ehMSbS+vesFsLGiD6JXu3mVEzOlfUl8wNnq+x/9p0=
@@ -265,8 +266,8 @@ github.com/gardener/hvpa-controller v0.3.1/go.mod h1:rjsb3BPKJFMluudZ8/bhCCDQfFC
 github.com/gardener/machine-controller-manager v0.27.0/go.mod h1:zlIxuLQMtRO+aXOFsG6qtYkBmggbWY82K7MSO051ARU=
 github.com/gardener/machine-controller-manager v0.33.0 h1:58Gh4MW7Yv9XoARKhP4wORDcn2Hofbuv/1OlMe9y1eY=
 github.com/gardener/machine-controller-manager v0.33.0/go.mod h1:jxxE+mGgXwg4iPlCHTG4GtUfK2CcHA6yYoIIowoxOZU=
-github.com/gardener/machine-controller-manager v0.35.0 h1:0kMJrMPsK8oohxDfE6Uc2dlJ2YZTSK70QZiVIyuGS2k=
-github.com/gardener/machine-controller-manager v0.35.0/go.mod h1:jxxE+mGgXwg4iPlCHTG4GtUfK2CcHA6yYoIIowoxOZU=
+github.com/gardener/machine-controller-manager v0.37.0 h1:am2FNCmBNQyNwsagsqH/tEYdDADzPH5a0UCClX3V6JA=
+github.com/gardener/machine-controller-manager v0.37.0/go.mod h1:Be9VDEXC8fF62inu5kyq5pnzmBmaJOczDMYFQdhGDWk=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/types.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/types.go
@@ -649,22 +649,23 @@ type OpenStackMachineClassList struct {
 
 // OpenStackMachineClassSpec is the specification of a OpenStackMachineClass.
 type OpenStackMachineClassSpec struct {
-	ImageID          string
-	ImageName        string
-	Region           string
-	AvailabilityZone string
-	FlavorName       string
-	KeyName          string
-	SecurityGroups   []string
-	Tags             map[string]string
-	NetworkID        string
-	Networks         []OpenStackNetwork
-	SubnetID         *string
-	SecretRef        *corev1.SecretReference
-	PodNetworkCidr   string
-	RootDiskSize     int // in GB
-	UseConfigDrive   *bool
-	ServerGroupID    *string
+	ImageID              string
+	ImageName            string
+	Region               string
+	AvailabilityZone     string
+	FlavorName           string
+	KeyName              string
+	SecurityGroups       []string
+	Tags                 map[string]string
+	NetworkID            string
+	Networks             []OpenStackNetwork
+	SubnetID             *string
+	SecretRef            *corev1.SecretReference
+	CredentialsSecretRef *corev1.SecretReference
+	PodNetworkCidr       string
+	RootDiskSize         int // in GB
+	UseConfigDrive       *bool
+	ServerGroupID        *string
 }
 
 type OpenStackNetwork struct {
@@ -700,18 +701,19 @@ type AWSMachineClassList struct {
 
 // AWSMachineClassSpec is the specification of a AWSMachineClass.
 type AWSMachineClassSpec struct {
-	AMI               string
-	Region            string
-	BlockDevices      []AWSBlockDeviceMappingSpec
-	EbsOptimized      bool
-	IAM               AWSIAMProfileSpec
-	MachineType       string
-	KeyName           string
-	Monitoring        bool
-	NetworkInterfaces []AWSNetworkInterfaceSpec
-	Tags              map[string]string
-	SpotPrice         *string
-	SecretRef         *corev1.SecretReference
+	AMI                  string
+	Region               string
+	BlockDevices         []AWSBlockDeviceMappingSpec
+	EbsOptimized         bool
+	IAM                  AWSIAMProfileSpec
+	MachineType          string
+	KeyName              string
+	Monitoring           bool
+	NetworkInterfaces    []AWSNetworkInterfaceSpec
+	Tags                 map[string]string
+	SpotPrice            *string
+	SecretRef            *corev1.SecretReference
+	CredentialsSecretRef *corev1.SecretReference
 
 	// TODO add more here
 }
@@ -863,12 +865,13 @@ type AzureMachineClassList struct {
 
 // AzureMachineClassSpec is the specification of a AzureMachineClass.
 type AzureMachineClassSpec struct {
-	Location      string
-	Tags          map[string]string
-	Properties    AzureVirtualMachineProperties
-	ResourceGroup string
-	SubnetInfo    AzureSubnetInfo
-	SecretRef     *corev1.SecretReference
+	Location             string
+	Tags                 map[string]string
+	Properties           AzureVirtualMachineProperties
+	ResourceGroup        string
+	SubnetInfo           AzureSubnetInfo
+	SecretRef            *corev1.SecretReference
+	CredentialsSecretRef *corev1.SecretReference
 }
 
 // AzureVirtualMachineProperties is describes the properties of a Virtual Machine.
@@ -1029,20 +1032,21 @@ type GCPMachineClassList struct {
 
 // GCPMachineClassSpec is the specification of a GCPMachineClass.
 type GCPMachineClassSpec struct {
-	CanIpForward       bool
-	DeletionProtection bool
-	Description        *string
-	Disks              []*GCPDisk
-	Labels             map[string]string
-	MachineType        string
-	Metadata           []*GCPMetadata
-	NetworkInterfaces  []*GCPNetworkInterface
-	Scheduling         GCPScheduling
-	SecretRef          *corev1.SecretReference
-	ServiceAccounts    []GCPServiceAccount
-	Tags               []string
-	Region             string
-	Zone               string
+	CanIpForward         bool
+	DeletionProtection   bool
+	Description          *string
+	Disks                []*GCPDisk
+	Labels               map[string]string
+	MachineType          string
+	Metadata             []*GCPMetadata
+	NetworkInterfaces    []*GCPNetworkInterface
+	Scheduling           GCPScheduling
+	SecretRef            *corev1.SecretReference
+	CredentialsSecretRef *corev1.SecretReference
+	ServiceAccounts      []GCPServiceAccount
+	Tags                 []string
+	Region               string
+	Zone                 string
 }
 
 // GCPDisk describes disks for GCP.
@@ -1127,6 +1131,7 @@ type AlicloudMachineClassSpec struct {
 	Tags                    map[string]string
 	KeyPairName             string
 	SecretRef               *corev1.SecretReference
+	CredentialsSecretRef    *corev1.SecretReference
 }
 
 // AlicloudSystemDisk describes SystemDisk for Alicloud.
@@ -1181,7 +1186,8 @@ type PacketMachineClassSpec struct {
 	SSHKeys      []string
 	UserData     string
 
-	SecretRef *corev1.SecretReference
+	SecretRef            *corev1.SecretReference
+	CredentialsSecretRef *corev1.SecretReference
 
 	// TODO add more here
 }
@@ -1200,8 +1206,11 @@ type MachineClass struct {
 	metav1.ObjectMeta
 	// Provider-specific configuration to use during node creation.
 	ProviderSpec runtime.RawExtension
-	// SecretRef stores the necessary secrets such as credetials or userdata.
+	// SecretRef stores the necessary secrets such as credentials or userdata.
 	SecretRef *corev1.SecretReference
+	// CredentialsSecretRef can optionally store the credentials (in this case the SecretRef does not need to store them).
+	// This might be useful if multiple machine classes with the same credentials but different user-datas are used.
+	CredentialsSecretRef *corev1.SecretReference
 	// Provider is the combination of name and location of cloud-specific drivers.
 	// eg. awsdriver//127.0.0.1:8080
 	Provider string

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/alicoud_machineclass_types.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/alicoud_machineclass_types.go
@@ -28,6 +28,13 @@ const (
 	AlicloudAccessKeyID string = "alicloudAccessKeyID"
 	// AlicloudAccessKeySecret is a constant for a key name that is part of the Alibaba cloud credentials.
 	AlicloudAccessKeySecret string = "alicloudAccessKeySecret"
+
+	// AlicloudAlternativeAccessKeyID is a constant for a key name of a secret containing the Alibaba cloud
+	// credentials (access key id).
+	AlicloudAlternativeAccessKeyID = "accessKeyID"
+	// AlicloudAlternativeAccessKeySecret is a constant for a key name of a secret containing the Alibaba cloud
+	// credentials (access key secret).
+	AlicloudAlternativeAccessKeySecret = "accessKeySecret"
 )
 
 // +genclient
@@ -84,6 +91,7 @@ type AlicloudMachineClassSpec struct {
 	Tags                    map[string]string       `json:"tags,omitempty"`
 	KeyPairName             string                  `json:"keyPairName"`
 	SecretRef               *corev1.SecretReference `json:"secretRef,omitempty"`
+	CredentialsSecretRef    *corev1.SecretReference `json:"credentialsSecretRef,omitempty"`
 }
 
 type AlicloudDataDisk struct {

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/aws_machineclass_types.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/aws_machineclass_types.go
@@ -28,6 +28,13 @@ const (
 	AWSAccessKeyID string = "providerAccessKeyId"
 	// AWSSecretAccessKey is a constant for a key name that is part of the AWS cloud credentials.
 	AWSSecretAccessKey string = "providerSecretAccessKey"
+
+	// AWSAlternativeAccessKeyID is a constant for a key name of a secret containing the AWS credentials (access key
+	// id).
+	AWSAlternativeAccessKeyID = "accessKeyID"
+	// AWSAlternativeAccessKeySecret is a constant for a key name of a secret containing the AWS credentials (access key
+	// secret).
+	AWSAlternativeSecretAccessKey = "secretAccessKey"
 )
 
 // +genclient
@@ -67,18 +74,19 @@ type AWSMachineClassList struct {
 
 // AWSMachineClassSpec is the specification of a AWSMachineClass.
 type AWSMachineClassSpec struct {
-	AMI               string                      `json:"ami,omitempty"`
-	Region            string                      `json:"region,omitempty"`
-	BlockDevices      []AWSBlockDeviceMappingSpec `json:"blockDevices,omitempty"`
-	EbsOptimized      bool                        `json:"ebsOptimized,omitempty"`
-	IAM               AWSIAMProfileSpec           `json:"iam,omitempty"`
-	MachineType       string                      `json:"machineType,omitempty"`
-	KeyName           string                      `json:"keyName,omitempty"`
-	Monitoring        bool                        `json:"monitoring,omitempty"`
-	NetworkInterfaces []AWSNetworkInterfaceSpec   `json:"networkInterfaces,omitempty"`
-	Tags              map[string]string           `json:"tags,omitempty"`
-	SpotPrice         *string                     `json:"spotPrice,omitempty"`
-	SecretRef         *corev1.SecretReference     `json:"secretRef,omitempty"`
+	AMI                  string                      `json:"ami,omitempty"`
+	Region               string                      `json:"region,omitempty"`
+	BlockDevices         []AWSBlockDeviceMappingSpec `json:"blockDevices,omitempty"`
+	EbsOptimized         bool                        `json:"ebsOptimized,omitempty"`
+	IAM                  AWSIAMProfileSpec           `json:"iam,omitempty"`
+	MachineType          string                      `json:"machineType,omitempty"`
+	KeyName              string                      `json:"keyName,omitempty"`
+	Monitoring           bool                        `json:"monitoring,omitempty"`
+	NetworkInterfaces    []AWSNetworkInterfaceSpec   `json:"networkInterfaces,omitempty"`
+	Tags                 map[string]string           `json:"tags,omitempty"`
+	SpotPrice            *string                     `json:"spotPrice,omitempty"`
+	SecretRef            *corev1.SecretReference     `json:"secretRef,omitempty"`
+	CredentialsSecretRef *corev1.SecretReference     `json:"credentialsSecretRef,omitempty"`
 
 	// TODO add more here
 }

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/azure_machineclass_types.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/azure_machineclass_types.go
@@ -32,6 +32,17 @@ const (
 	AzureSubscriptionID string = "azureSubscriptionId"
 	// AzureTenantID is a constant for a key name that is part of the Azure cloud credentials.
 	AzureTenantID string = "azureTenantId"
+
+	// AzureAlternativeClientID is a constant for a key name of a secret containing the Azure credentials (client id).
+	AzureAlternativeClientID = "clientID"
+	// AzureAlternativeClientSecret is a constant for a key name of a secret containing the Azure credentials (client
+	// secret).
+	AzureAlternativeClientSecret = "clientSecret"
+	// AzureAlternativeSubscriptionID is a constant for a key name of a secret containing the Azure credentials
+	// (subscription id).
+	AzureAlternativeSubscriptionID = "subscriptionID"
+	// AzureAlternativeTenantID is a constant for a key name of a secret containing the Azure credentials (tenant id).
+	AzureAlternativeTenantID = "tenantID"
 )
 
 // +genclient
@@ -70,12 +81,13 @@ type AzureMachineClassList struct {
 
 // AzureMachineClassSpec is the specification of a AzureMachineClass.
 type AzureMachineClassSpec struct {
-	Location      string                        `json:"location,omitempty"`
-	Tags          map[string]string             `json:"tags,omitempty"`
-	Properties    AzureVirtualMachineProperties `json:"properties,omitempty"`
-	ResourceGroup string                        `json:"resourceGroup,omitempty"`
-	SubnetInfo    AzureSubnetInfo               `json:"subnetInfo,omitempty"`
-	SecretRef     *corev1.SecretReference       `json:"secretRef,omitempty"`
+	Location             string                        `json:"location,omitempty"`
+	Tags                 map[string]string             `json:"tags,omitempty"`
+	Properties           AzureVirtualMachineProperties `json:"properties,omitempty"`
+	ResourceGroup        string                        `json:"resourceGroup,omitempty"`
+	SubnetInfo           AzureSubnetInfo               `json:"subnetInfo,omitempty"`
+	SecretRef            *corev1.SecretReference       `json:"secretRef,omitempty"`
+	CredentialsSecretRef *corev1.SecretReference       `json:"credentialsSecretRef,omitempty"`
 }
 
 // AzureVirtualMachineProperties is describes the properties of a Virtual Machine.

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/gcp_machineclass_types.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/gcp_machineclass_types.go
@@ -26,6 +26,10 @@ import (
 const (
 	// GCPServiceAccountJSON is a constant for a key name that is part of the GCP cloud credentials.
 	GCPServiceAccountJSON string = "serviceAccountJSON"
+
+	// GCPAlternativeServiceAccountJSON is a constant for a key name of a secret containing the GCP credentials (service
+	// account json).
+	GCPAlternativeServiceAccountJSON = "serviceaccount.json"
 )
 
 // +genclient
@@ -64,20 +68,21 @@ type GCPMachineClassList struct {
 
 // GCPMachineClassSpec is the specification of a GCPMachineClass.
 type GCPMachineClassSpec struct {
-	CanIpForward       bool                    `json:"canIpForward"`
-	DeletionProtection bool                    `json:"deletionProtection"`
-	Description        *string                 `json:"description,omitempty"`
-	Disks              []*GCPDisk              `json:"disks,omitempty"`
-	Labels             map[string]string       `json:"labels,omitempty"`
-	MachineType        string                  `json:"machineType"`
-	Metadata           []*GCPMetadata          `json:"metadata,omitempty"`
-	NetworkInterfaces  []*GCPNetworkInterface  `json:"networkInterfaces,omitempty"`
-	Scheduling         GCPScheduling           `json:"scheduling"`
-	SecretRef          *corev1.SecretReference `json:"secretRef,omitempty"`
-	ServiceAccounts    []GCPServiceAccount     `json:"serviceAccounts"`
-	Tags               []string                `json:"tags,omitempty"`
-	Region             string                  `json:"region"`
-	Zone               string                  `json:"zone"`
+	CanIpForward         bool                    `json:"canIpForward"`
+	DeletionProtection   bool                    `json:"deletionProtection"`
+	Description          *string                 `json:"description,omitempty"`
+	Disks                []*GCPDisk              `json:"disks,omitempty"`
+	Labels               map[string]string       `json:"labels,omitempty"`
+	MachineType          string                  `json:"machineType"`
+	Metadata             []*GCPMetadata          `json:"metadata,omitempty"`
+	NetworkInterfaces    []*GCPNetworkInterface  `json:"networkInterfaces,omitempty"`
+	Scheduling           GCPScheduling           `json:"scheduling"`
+	SecretRef            *corev1.SecretReference `json:"secretRef,omitempty"`
+	CredentialsSecretRef *corev1.SecretReference `json:"credentialsSecretRef,omitempty"`
+	ServiceAccounts      []GCPServiceAccount     `json:"serviceAccounts"`
+	Tags                 []string                `json:"tags,omitempty"`
+	Region               string                  `json:"region"`
+	Zone                 string                  `json:"zone"`
 }
 
 // GCPDisk describes disks for GCP.

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/machineclass_types.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/machineclass_types.go
@@ -39,8 +39,11 @@ type MachineClass struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Provider-specific configuration to use during node creation.
 	ProviderSpec runtime.RawExtension `json:"providerSpec"`
-	// SecretRef stores the necessary secrets such as credetials or userdata.
+	// SecretRef stores the necessary secrets such as credentials or userdata.
 	SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
+	// CredentialsSecretRef can optionally store the credentials (in this case the SecretRef does not need to store them).
+	// This might be useful if multiple machine classes with the same credentials but different user-datas are used.
+	CredentialsSecretRef *corev1.SecretReference `json:"credentialsSecretRef,omitempty"`
 	// Provider is the combination of name and location of cloud-specific drivers.
 	Provider string `json:"provider,omitempty"`
 }

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/openstack_machineclass_types.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/openstack_machineclass_types.go
@@ -88,22 +88,23 @@ type OpenStackMachineClassList struct {
 
 // OpenStackMachineClassSpec is the specification of a OpenStackMachineClass.
 type OpenStackMachineClassSpec struct {
-	ImageID          string                  `json:"imageID"`
-	ImageName        string                  `json:"imageName"`
-	Region           string                  `json:"region"`
-	AvailabilityZone string                  `json:"availabilityZone"`
-	FlavorName       string                  `json:"flavorName"`
-	KeyName          string                  `json:"keyName"`
-	SecurityGroups   []string                `json:"securityGroups"`
-	Tags             map[string]string       `json:"tags,omitempty"`
-	NetworkID        string                  `json:"networkID"`
-	Networks         []OpenStackNetwork      `json:"networks,omitempty"`
-	SubnetID         *string                 `json:"subnetID,omitempty"`
-	SecretRef        *corev1.SecretReference `json:"secretRef,omitempty"`
-	PodNetworkCidr   string                  `json:"podNetworkCidr"`
-	RootDiskSize     int                     `json:"rootDiskSize,omitempty"` // in GB
-	UseConfigDrive   *bool                   `json:"useConfigDrive,omitempty"`
-	ServerGroupID    *string                 `json:"serverGroupID,omitempty"`
+	ImageID              string                  `json:"imageID"`
+	ImageName            string                  `json:"imageName"`
+	Region               string                  `json:"region"`
+	AvailabilityZone     string                  `json:"availabilityZone"`
+	FlavorName           string                  `json:"flavorName"`
+	KeyName              string                  `json:"keyName"`
+	SecurityGroups       []string                `json:"securityGroups"`
+	Tags                 map[string]string       `json:"tags,omitempty"`
+	NetworkID            string                  `json:"networkID"`
+	Networks             []OpenStackNetwork      `json:"networks,omitempty"`
+	SubnetID             *string                 `json:"subnetID,omitempty"`
+	SecretRef            *corev1.SecretReference `json:"secretRef,omitempty"`
+	CredentialsSecretRef *corev1.SecretReference `json:"credentialsSecretRef,omitempty"`
+	PodNetworkCidr       string                  `json:"podNetworkCidr"`
+	RootDiskSize         int                     `json:"rootDiskSize,omitempty"` // in GB
+	UseConfigDrive       *bool                   `json:"useConfigDrive,omitempty"`
+	ServerGroupID        *string                 `json:"serverGroupID,omitempty"`
 }
 
 type OpenStackNetwork struct {

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/packet_machineclass_types.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/packet_machineclass_types.go
@@ -71,5 +71,6 @@ type PacketMachineClassSpec struct {
 	SSHKeys      []string `json:"sshKeys,omitempty"`
 	UserData     string   `json:"userdata,omitempty"`
 
-	SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
+	SecretRef            *corev1.SecretReference `json:"secretRef,omitempty"`
+	CredentialsSecretRef *corev1.SecretReference `json:"credentialsSecretRef,omitempty"`
 }

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -918,6 +918,7 @@ func autoConvert_v1alpha1_AWSMachineClassSpec_To_machine_AWSMachineClassSpec(in 
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	out.SpotPrice = (*string)(unsafe.Pointer(in.SpotPrice))
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -941,6 +942,7 @@ func autoConvert_machine_AWSMachineClassSpec_To_v1alpha1_AWSMachineClassSpec(in 
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	out.SpotPrice = (*string)(unsafe.Pointer(in.SpotPrice))
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -1104,6 +1106,7 @@ func autoConvert_v1alpha1_AlicloudMachineClassSpec_To_machine_AlicloudMachineCla
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	out.KeyPairName = in.KeyPairName
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -1141,6 +1144,7 @@ func autoConvert_machine_AlicloudMachineClassSpec_To_v1alpha1_AlicloudMachineCla
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	out.KeyPairName = in.KeyPairName
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -1326,6 +1330,7 @@ func autoConvert_v1alpha1_AzureMachineClassSpec_To_machine_AzureMachineClassSpec
 		return err
 	}
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -1345,6 +1350,7 @@ func autoConvert_machine_AzureMachineClassSpec_To_v1alpha1_AzureMachineClassSpec
 		return err
 	}
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -1842,6 +1848,7 @@ func autoConvert_v1alpha1_GCPMachineClassSpec_To_machine_GCPMachineClassSpec(in 
 		return err
 	}
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	out.ServiceAccounts = *(*[]machine.GCPServiceAccount)(unsafe.Pointer(&in.ServiceAccounts))
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.Region = in.Region
@@ -1867,6 +1874,7 @@ func autoConvert_machine_GCPMachineClassSpec_To_v1alpha1_GCPMachineClassSpec(in 
 		return err
 	}
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	out.ServiceAccounts = *(*[]GCPServiceAccount)(unsafe.Pointer(&in.ServiceAccounts))
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.Region = in.Region
@@ -2033,6 +2041,7 @@ func autoConvert_v1alpha1_MachineClass_To_machine_MachineClass(in *MachineClass,
 	out.ObjectMeta = in.ObjectMeta
 	out.ProviderSpec = in.ProviderSpec
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	out.Provider = in.Provider
 	return nil
 }
@@ -2046,6 +2055,7 @@ func autoConvert_machine_MachineClass_To_v1alpha1_MachineClass(in *machine.Machi
 	out.ObjectMeta = in.ObjectMeta
 	out.ProviderSpec = in.ProviderSpec
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	out.Provider = in.Provider
 	return nil
 }
@@ -2678,6 +2688,7 @@ func autoConvert_v1alpha1_OpenStackMachineClassSpec_To_machine_OpenStackMachineC
 	out.Networks = *(*[]machine.OpenStackNetwork)(unsafe.Pointer(&in.Networks))
 	out.SubnetID = (*string)(unsafe.Pointer(in.SubnetID))
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	out.PodNetworkCidr = in.PodNetworkCidr
 	out.RootDiskSize = in.RootDiskSize
 	out.UseConfigDrive = (*bool)(unsafe.Pointer(in.UseConfigDrive))
@@ -2703,6 +2714,7 @@ func autoConvert_machine_OpenStackMachineClassSpec_To_v1alpha1_OpenStackMachineC
 	out.Networks = *(*[]OpenStackNetwork)(unsafe.Pointer(&in.Networks))
 	out.SubnetID = (*string)(unsafe.Pointer(in.SubnetID))
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	out.PodNetworkCidr = in.PodNetworkCidr
 	out.RootDiskSize = in.RootDiskSize
 	out.UseConfigDrive = (*bool)(unsafe.Pointer(in.UseConfigDrive))
@@ -2797,6 +2809,7 @@ func autoConvert_v1alpha1_PacketMachineClassSpec_To_machine_PacketMachineClassSp
 	out.SSHKeys = *(*[]string)(unsafe.Pointer(&in.SSHKeys))
 	out.UserData = in.UserData
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -2815,6 +2828,7 @@ func autoConvert_machine_PacketMachineClassSpec_To_v1alpha1_PacketMachineClassSp
 	out.SSHKeys = *(*[]string)(unsafe.Pointer(&in.SSHKeys))
 	out.UserData = in.UserData
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
@@ -186,6 +186,11 @@ func (in *AWSMachineClassSpec) DeepCopyInto(out *AWSMachineClassSpec) {
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	return
 }
 
@@ -350,6 +355,11 @@ func (in *AlicloudMachineClassSpec) DeepCopyInto(out *AlicloudMachineClassSpec) 
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
@@ -531,6 +541,11 @@ func (in *AzureMachineClassSpec) DeepCopyInto(out *AzureMachineClassSpec) {
 	in.SubnetInfo.DeepCopyInto(&out.SubnetInfo)
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
@@ -982,6 +997,11 @@ func (in *GCPMachineClassSpec) DeepCopyInto(out *GCPMachineClassSpec) {
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	if in.ServiceAccounts != nil {
 		in, out := &in.ServiceAccounts, &out.ServiceAccounts
 		*out = make([]GCPServiceAccount, len(*in))
@@ -1134,6 +1154,11 @@ func (in *MachineClass) DeepCopyInto(out *MachineClass) {
 	in.ProviderSpec.DeepCopyInto(&out.ProviderSpec)
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
@@ -1769,6 +1794,11 @@ func (in *OpenStackMachineClassSpec) DeepCopyInto(out *OpenStackMachineClassSpec
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	if in.UseConfigDrive != nil {
 		in, out := &in.UseConfigDrive, &out.UseConfigDrive
 		*out = new(bool)
@@ -1888,6 +1918,11 @@ func (in *PacketMachineClassSpec) DeepCopyInto(out *PacketMachineClassSpec) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}

--- a/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/zz_generated.deepcopy.go
+++ b/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/zz_generated.deepcopy.go
@@ -186,6 +186,11 @@ func (in *AWSMachineClassSpec) DeepCopyInto(out *AWSMachineClassSpec) {
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	return
 }
 
@@ -350,6 +355,11 @@ func (in *AlicloudMachineClassSpec) DeepCopyInto(out *AlicloudMachineClassSpec) 
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
@@ -531,6 +541,11 @@ func (in *AzureMachineClassSpec) DeepCopyInto(out *AzureMachineClassSpec) {
 	in.SubnetInfo.DeepCopyInto(&out.SubnetInfo)
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
@@ -982,6 +997,11 @@ func (in *GCPMachineClassSpec) DeepCopyInto(out *GCPMachineClassSpec) {
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	if in.ServiceAccounts != nil {
 		in, out := &in.ServiceAccounts, &out.ServiceAccounts
 		*out = make([]GCPServiceAccount, len(*in))
@@ -1134,6 +1154,11 @@ func (in *MachineClass) DeepCopyInto(out *MachineClass) {
 	in.ProviderSpec.DeepCopyInto(&out.ProviderSpec)
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
@@ -1862,6 +1887,11 @@ func (in *OpenStackMachineClassSpec) DeepCopyInto(out *OpenStackMachineClassSpec
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	if in.UseConfigDrive != nil {
 		in, out := &in.UseConfigDrive, &out.UseConfigDrive
 		*out = new(bool)
@@ -1981,6 +2011,11 @@ func (in *PacketMachineClassSpec) DeepCopyInto(out *PacketMachineClassSpec) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -200,7 +200,7 @@ github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1
 github.com/gardener/gardener-resource-manager/pkg/manager
 # github.com/gardener/hvpa-controller v0.3.1
 github.com/gardener/hvpa-controller/api/v1alpha1
-# github.com/gardener/machine-controller-manager v0.35.0
+# github.com/gardener/machine-controller-manager v0.37.0
 ## explicit
 github.com/gardener/machine-controller-manager/pkg/apis/machine
 github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind task
/priority normal
/platform vsphere

**What this PR does / why we need it**:
updated image of mcm-provider-vsphere to v0.9.0 and extended clusterrole on shoot as mcm v0.37.0 now watches poddisruptionbudgets.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
``` improvement operator github.com/gardener/machine-controller-manager-provider-vsphere #10 @MartinWeindel
updated machine-controller-manager dependency to v0.37.0
```
