### PR TITLE
vsphere-csi-driver v2.1.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,21 +2,21 @@ images:
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher
-  tag: v2.2.0
+  tag: v3.0.0
   targetVersion: ">= 1.14"
 - name: csi-resizer
   sourceRepository: github.com/kubernetes-csi/external-resizer
   repository: quay.io/k8scsi/csi-resizer
-  tag: v0.5.0
+  tag: v1.0.0
 - name: csi-node-driver-registrar
   sourceRepository: https://github.com/kubernetes-csi/node-driver-registrar
   repository: quay.io/k8scsi/csi-node-driver-registrar
-  tag: v1.3.0
+  tag: v2.0.1
   targetVersion: ">= 1.14"
 - name: csi-provisioner
   sourceRepository: https://github.com/kubernetes-csi/external-provisioner
   repository: quay.io/k8scsi/csi-provisioner
-  tag: v1.6.0
+  tag: v2.0.0
   targetVersion: ">= 1.14"
 - name: vsphere-cloud-controller-manager
   sourceRepository: github.com/MartinWeindel/cloud-provider-vsphere
@@ -38,16 +38,16 @@ images:
   #tag: v2.0.1
   sourceRepository: github.com/MartinWeindel/vsphere-csi-driver
   repository: eu.gcr.io/gardener-project/patches/vsphere-csi-driver/driver
-  tag: v2.0.1-gardener1
+  tag: v2.1.1-gardener1
 - name: vsphere-csi-driver-node
   sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   repository: gcr.io/cloud-provider-vsphere/csi/release/driver
-  tag: v2.0.1
+  tag: v2.1.1
 - name: vsphere-csi-driver-syncer
   sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   repository: gcr.io/cloud-provider-vsphere/csi/release/syncer
-  tag: v2.0.1
+  tag: v2.1.1
 - name: liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: quay.io/k8scsi/livenessprobe
-  tag: v2.0.0
+  tag: v2.1.0

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/vsphere-csi-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/vsphere-csi-controller.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-        - name: vsphere-csi-attacher
+        - name: csi-attacher
           image: {{ index .Values.images "csi-attacher" }}
           args:
             - "--v=4"
@@ -58,11 +58,11 @@ spec:
             - name: csi-attacher
               mountPath: /var/lib/csi-attacher
 {{- if .Values.resizerEnabled }}
-        - name: vsphere-csi-resizer
+        - name: csi-resizer
           image: {{ index .Values.images "csi-resizer" }}
           args:
             - "--v=4"
-            - "--csiTimeout=300s"
+            - "--timeout=300s"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
             - --kubeconfig=/var/lib/csi-resizer/kubeconfig
@@ -81,17 +81,27 @@ spec:
 {{- end }}
         - name: vsphere-csi-controller
           image: {{ index .Values.images "vsphere-csi-driver-controller" }}
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+            - "--kubeconfig=/var/lib/vsphere-csi-controller/kubeconfig"
           env:
-            - name: KUBECONFIG
-              value: /var/lib/vsphere-csi-controller/kubeconfig
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+              value: unix:///csi/csi.sock
             - name: X_CSI_MODE
               value: "controller"
             - name: VSPHERE_CSI_CONFIG
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "{{ .Values.loggerLevel }}" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 {{- if .Values.resources.controller }}
           resources:
 {{ toYaml .Values.resources.controller | indent 12 }}
@@ -100,7 +110,7 @@ spec:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /var/lib/csi/sockets/pluginproxy/
+            - mountPath: /csi
               name: socket-dir
             - name: vsphere-csi-controller
               mountPath: /var/lib/vsphere-csi-controller
@@ -121,6 +131,8 @@ spec:
           args:
             - "--leader-election"
             - "--kubeconfig=/var/lib/csi-syncer/kubeconfig"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
               value: "30"
@@ -128,6 +140,14 @@ spec:
               value: "/etc/cloud/csi-vsphere.conf"
             - name: LOGGER_LEVEL
               value: "{{ .Values.loggerLevel }}" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 {{- if .Values.resources.syncer }}
           resources:
 {{ toYaml .Values.resources.syncer | indent 12 }}
@@ -138,13 +158,11 @@ spec:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
               readOnly: true
-        - name: vsphere-csi-liveness-probe
+        - name: csi-liveness-probe
           image: {{ index .Values.images "liveness-probe" }}
           args:
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /csi/csi.sock
+            - "--v=4"
+            - "--csi-address=/csi/csi.sock"
 {{- if .Values.resources.liveness }}
           resources:
 {{ toYaml .Values.resources.liveness | indent 12 }}
@@ -152,20 +170,17 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-        - name: vsphere-csi-provisioner
+        - name: csi-provisioner
           image: {{ index .Values.images "csi-provisioner" }}
           args:
             - "--v=4"
             - "--timeout=300s"
-            - "--csi-address=$(ADDRESS)"
+            - "--csi-address=/csi/csi.sock"
             - "--feature-gates=Topology=true"
             - "--strict-topology"
-            - "--enable-leader-election"
-            - "--leader-election-type=leases"
+            - "--leader-election"
             - "--kubeconfig=/var/lib/csi-provisioner/kubeconfig"
-          env:
-            - name: ADDRESS
-              value: /csi/csi.sock
+            - "--default-fstype=ext4"
 {{- if .Values.resources.provisioner }}
           resources:
 {{ toYaml .Values.resources.provisioner | indent 12 }}
@@ -196,6 +211,14 @@ spec:
             secretName: csi-vsphere-config
         - name: socket-dir
           emptyDir: {}
+---
+apiVersion: v1
+data:
+  "csi-migration": "false" # csi-migration feature is only available for vSphere 7.0U1
+kind: ConfigMap
+metadata:
+  name: internal-feature-states.csi.vsphere.vmware.com
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area storage
/kind task
/priority 3
/platform vsphere

**What this PR does / why we need it**:
Update vsphere-csi-driver to v2.1.1. This includes updates of the csi containers (attacher,provisioner,resizer,...)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
update to vsphere-csi-driver v2.1.1
```
