### PR TITLE
Fix the infrastructure-test TestDefinition

### DIFF
--- a/.test-defs/infrastructure-test.yaml
+++ b/.test-defs/infrastructure-test.yaml
@@ -19,4 +19,4 @@ spec:
       --nsxt-t0-gateway="${NSXT_T0_GATEWAY}" \
       --nsxt-edge-cluster="${NSXT_EDGE_CLUSTER}" \
       --nsxt-snat-ip-pool="${NSXT_SNAP_IP_POOL}"
-  image: golang:1.14
+  image: golang:1.16.3

--- a/.test-defs/provider-vsphere.yaml
+++ b/.test-defs/provider-vsphere.yaml
@@ -12,4 +12,4 @@ spec:
       go run -mod=vendor ./test/tm/generator.go
       --infrastructure-provider-config-filepath=$INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
       --controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
-  image: golang:1.13.0
+  image: golang:1.16.3

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/
 
 You can run the controller locally on your machine by executing `make start`.
 
-Static code checks and tests can be executed by running `VERIFY=true make all`. We are using Go modules for Golang package dependency management and [Ginkgo](https://github.com/onsi/ginkgo)/[Gomega](https://github.com/onsi/gomega) for testing.
+Static code checks and tests can be executed by running `make verify`. We are using Go modules for Golang package dependency management and [Ginkgo](https://github.com/onsi/ginkgo)/[Gomega](https://github.com/onsi/gomega) for testing.
 
 ## Feedback and Support
 


### PR DESCRIPTION
/kind bug

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/311

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
