### PR TITLE
updated the provider name in the machine class template 

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -68,5 +68,5 @@ providerSpec:
 secretRef:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
-provider: vspheredriver//127.0.0.1:8080
+provider: vsphere
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/platform vsphere

**What this PR does / why we need it**:
Updated the provider name in the machine class template to match with the OOT

**Which issue(s) this PR fixes**:
Fixes [#599](https://github.com/gardener/machine-controller-manager/issues/599)

**Special notes for your reviewer**:
This change is in reference to [this](https://github.com/gardener/machine-controller-manager-provider-vsphere/pull/11#issuecomment-817295913) comment

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
