### PR TITLE
Automated cherry pick of #147: Do not require strict decoding for Shoot resource

### DIFF
--- a/pkg/validator/shoot_handler.go
+++ b/pkg/validator/shoot_handler.go
@@ -33,10 +33,9 @@ import (
 
 // Shoot validates shoots
 type Shoot struct {
-	client         client.Client
-	decoder        runtime.Decoder
-	lenientDecoder runtime.Decoder
-	Logger         logr.Logger
+	client  client.Client
+	decoder runtime.Decoder
+	Logger  logr.Logger
 }
 
 // Handle implements Handler.Handle
@@ -59,7 +58,7 @@ func (v *Shoot) Handle(ctx context.Context, req admission.Request) admission.Res
 		}
 	case admissionv1.Update:
 		oldShoot := &core.Shoot{}
-		if err := util.Decode(v.lenientDecoder, req.OldObject.Raw, oldShoot); err != nil {
+		if err := util.Decode(v.decoder, req.OldObject.Raw, oldShoot); err != nil {
 			v.Logger.Error(err, "failed to decode old shoot", "old shoot", string(req.OldObject.Raw))
 			return admission.Errored(http.StatusBadRequest, err)
 		}
@@ -83,7 +82,6 @@ func (v *Shoot) InjectClient(c client.Client) error {
 
 // InjectScheme injects the scheme.
 func (v *Shoot) InjectScheme(s *runtime.Scheme) error {
-	v.decoder = serializer.NewCodecFactory(s, serializer.EnableStrict).UniversalDecoder()
-	v.lenientDecoder = serializer.NewCodecFactory(s).UniversalDecoder()
+	v.decoder = serializer.NewCodecFactory(s).UniversalDecoder()
 	return nil
 }


### PR DESCRIPTION
/kind bug
/platform vsphere

Cherry pick of #147 on release-v0.7.

#147: Do not require strict decoding for Shoot resource

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing decoding of a Shoot resource to fail because of strict decoding is now fixed.
```