### PR TITLE
Update kubernetes-csi/livenessprobe

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -46,5 +46,5 @@ images:
   tag: v2.1.1
 - name: liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
-  repository: quay.io/k8scsi/livenessprobe
-  tag: v2.1.0
+  repository: k8s.gcr.io/sig-storage/livenessprobe
+  tag: v2.2.0


### PR DESCRIPTION
/kind bug
/platform vsphere

`kubernetes-csi/livenessprobe@v2.1.0` is affected by memory leak - see https://github.com/kubernetes-csi/livenessprobe/issues/91. 

The memory leak can be observed by checking the livenessprobe sidecar memory usage of a random Shoot:

<img width="1610" alt="Screenshot 2021-05-03 at 19 26 39" src="https://user-images.githubusercontent.com/9372594/116904300-31e96680-ac46-11eb-947a-838eb8913f74.png">

Sibling PR - https://github.com/gardener/gardener-extension-provider-openstack/pull/256.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The following image is updated (see [CHANGELOG](https://github.com/kubernetes-csi/livenessprobe/blob/v2.2.0/CHANGELOG/CHANGELOG-2.2.md) for more details):
- k8s.gcr.io/sig-storage/livenessprobe: v2.1.0 -> v2.2.0
```

