### PR TITLE
Expose logs from user exposed components in the new way

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/configmap-observability.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/configmap-observability.yaml
@@ -13,3 +13,8 @@ data:
   dashboard_users: |
     vsphere-csi-controller-dashboard.json: |-
 {{- .Files.Get "vsphere-csi-controller-dashboard.json" | nindent 6 }}
+
+  observedComponents: |
+    observedPods:
+    - podPrefix: csi-driver-controller
+      isExposedToUser: true

--- a/charts/internal/seed-controlplane/charts/vsphere-cloud-controller-manager/templates/configmap-observability.yaml
+++ b/charts/internal/seed-controlplane/charts/vsphere-cloud-controller-manager/templates/configmap-observability.yaml
@@ -58,3 +58,8 @@ data:
   dashboard_users: |
     cloud-controller-manager-dashboard.json: |-
 {{- .Files.Get "ccm-dashboard.json" | nindent 6 }}
+
+  observedComponents: |
+    observedPods:
+    - podPrefix: cloud-controller-manager
+      isExposedToUser: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/platform vsphere

**What this PR does / why we need it**:
Adapt the extension to gardener/gardener#4060

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
