### PR TITLE
Fix admission RBACs after secret validation implementation

### DIFF
--- a/charts/gardener-extension-validator-vsphere/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-validator-vsphere/charts/application/templates/rbac.yaml
@@ -9,10 +9,19 @@ rules:
 - apiGroups:
   - core.gardener.cloud
   resources:
+  - shoots
   - cloudprofiles
+  - secretbindings
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
/kind bug


Similar to gardener/gardener-extension-provider-aws#346
Follow-up after #153

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
