### PR TITLE
updated vsphere-csi to v2.2.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,19 +2,19 @@ images:
 - name: csi-attacher
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher
-  tag: v3.0.0
+  tag: v3.1.0
 - name: csi-resizer
   sourceRepository: github.com/kubernetes-csi/external-resizer
   repository: quay.io/k8scsi/csi-resizer
-  tag: v1.0.0
+  tag: v1.1.0
 - name: csi-node-driver-registrar
   sourceRepository: https://github.com/kubernetes-csi/node-driver-registrar
   repository: quay.io/k8scsi/csi-node-driver-registrar
-  tag: v2.0.1
+  tag: v2.1.0
 - name: csi-provisioner
   sourceRepository: https://github.com/kubernetes-csi/external-provisioner
   repository: quay.io/k8scsi/csi-provisioner
-  tag: v2.0.0
+  tag: v2.1.0
 - name: vsphere-cloud-controller-manager
   sourceRepository: github.com/MartinWeindel/cloud-provider-vsphere
   repository: eu.gcr.io/gardener-project/test/cloud-provider-vsphere-martinweindel
@@ -35,15 +35,15 @@ images:
   #tag: v2.0.1
   sourceRepository: github.com/MartinWeindel/vsphere-csi-driver
   repository: eu.gcr.io/gardener-project/patches/vsphere-csi-driver/driver
-  tag: v2.1.1-gardener1
+  tag: v2.2.1-gardener1
 - name: vsphere-csi-driver-node
   sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   repository: gcr.io/cloud-provider-vsphere/csi/release/driver
-  tag: v2.1.1
+  tag: v2.2.1
 - name: vsphere-csi-driver-syncer
   sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   repository: gcr.io/cloud-provider-vsphere/csi/release/syncer
-  tag: v2.1.1
+  tag: v2.2.1
 - name: liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: k8s.gcr.io/sig-storage/livenessprobe

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/vsphere-csi-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/vsphere-csi-controller.yaml
@@ -64,7 +64,10 @@ spec:
           args:
             - "--v=4"
             - "--timeout=300s"
+            - "--handle-volume-inuse-error=false"
             - "--csi-address=$(ADDRESS)"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
             - "--leader-election"
             - --kubeconfig=/var/lib/csi-resizer/kubeconfig
           env:
@@ -118,6 +121,9 @@ spec:
           ports:
             - name: healthz
               containerPort: 9808
+              protocol: TCP
+            - name: prometheus
+              containerPort: 2112
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -177,6 +183,8 @@ spec:
             - "--v=4"
             - "--timeout=300s"
             - "--csi-address=/csi/csi.sock"
+            - "--kube-api-qps=100"
+            - "--kube-api-burst=100"
             - "--feature-gates=Topology=true"
             - "--strict-topology"
             - "--leader-election"

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/templates/configmap-internal-featurestate.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/templates/configmap-internal-featurestate.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  "csi-migration": "false"
+  "csi-auth-check": "true"
+  "online-volume-extend": "true"
+kind: ConfigMap
+metadata:
+  name: internal-feature-states.csi.vsphere.vmware.com
+  namespace: {{ .Release.Namespace }}

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       hostNetwork: true
       priorityClassName: system-node-critical
       serviceAccount: csi-driver-node
@@ -44,8 +44,6 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins_registry/csi.vsphere.vmware.com/csi.sock
-        securityContext:
-          privileged: true
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi
@@ -69,6 +67,12 @@ spec:
         - name: VSPHERE_CSI_CONFIG
           value: "/etc/cloud/csi-vsphere.conf" # here csi-vsphere.conf is the name of the file used for creating secret using "--from-file" flag
 {{- end }}
+        - name: LOGGER_LEVEL
+          value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           privileged: true
           capabilities:
@@ -87,6 +91,10 @@ spec:
             mountPropagation: "Bidirectional"
           - name: device-dir
             mountPath: /dev
+          - name: blocks-dir
+            mountPath: /sys/block
+          - name: sys-devices-dir
+            mountPath: /sys/devices
         ports:
           - name: healthz
             containerPort: 9808
@@ -128,3 +136,11 @@ spec:
         - name: device-dir
           hostPath:
             path: /dev
+        - name: blocks-dir
+          hostPath:
+            path: /sys/block
+            type: Directory
+        - name: sys-devices-dir
+          hostPath:
+            path: /sys/devices
+            type: Directory

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/templates/serviceaccount.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/templates/serviceaccount.yaml
@@ -4,3 +4,27 @@ kind: ServiceAccount
 metadata:
   name: csi-driver-node
   namespace: {{ .Release.Namespace }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-node-binding
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-driver-node
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: vsphere-csi-node-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind task
/platform vsphere

**What this PR does / why we need it**:
update of vsphere-csi driver to latest release v2.2.1

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
update of vsphere-csi driver to release v2.2.1
```
