### PR TITLE
using vsphere-csi-driver v2.3.0-gardener1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -56,9 +56,12 @@ images:
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-vsphere
   tag: "v0.10.0"
 - name: vsphere-csi-driver-controller
-  sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
-  repository: gcr.io/cloud-provider-vsphere/csi/release/driver
-  tag: v2.3.0
+  #sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
+  #repository: gcr.io/cloud-provider-vsphere/csi/release/driver
+  #tag: v2.3.0
+  sourceRepository: github.com/MartinWeindel/vsphere-csi-driver
+  repository: eu.gcr.io/gardener-project/patches/vsphere-csi-driver/driver
+  tag: v2.3.0-gardener1
 - name: vsphere-csi-driver-node
   sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   repository: gcr.io/cloud-provider-vsphere/csi/release/driver


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform vsphere

**What this PR does / why we need it**:
Patched version of vsphere-csi-driver is still needed to clean up volume attachments on hibernation.

**Special notes for your reviewer**:
See https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/529

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
using patched vsphere-csi-driver v2.3.0-gardener1 to fix volume attachment issue on hibernation
```
