### PR TITLE
Update mcm-provider-vsphere permissions, updated ccm to v1.22.4

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -42,11 +42,9 @@ images:
   tag: "v4.2.1"
   targetVersion: ">= 1.20"
 - name: vsphere-cloud-controller-manager
-  sourceRepository: github.com/MartinWeindel/cloud-provider-vsphere
-  repository: eu.gcr.io/gardener-project/test/cloud-provider-vsphere-martinweindel
-  tag: v1.22.0-patch1
-  #repository: gcr.io/cloud-provider-vsphere/cpi/release/manager
-  #tag: v1.0.0
+  sourceRepository: github.com/kubernetes/cloud-provider-vsphere
+  repository: gcr.io/cloud-provider-vsphere/cpi/release/manager
+  tag: v1.22.4
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
+++ b/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
@@ -67,3 +67,11 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|enhancement|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform vsphere

**What this PR does / why we need it**:
Update mcm-provider-vsphere permissions to list and watch `Volumeattachments`.
Updated vsphere-cloud-controller-manager image to cloud-provider-vsphere version `v1.22.4`


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated mcm-provider-vsphere permissions to list and watch volume attachments
```

```other operator
Updated vsphere-cloud-controller-manager image to cloud-provider-vsphere version `v1.22.4`
```