### PR TITLE
Remove the "garden.sapcloud.io/role" label from control plane components

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/deployment-vsphere-csi-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/deployment-vsphere-csi-controller.yaml
@@ -27,7 +27,6 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
-        garden.sapcloud.io/role: controlplane
         gardener.cloud/role: controlplane
         app: vsphere-csi-controller
         role: vsphere-csi

--- a/charts/internal/seed-controlplane/charts/vsphere-cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/vsphere-cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -21,7 +21,6 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
-        garden.sapcloud.io/role: controlplane
         gardener.cloud/role: controlplane
         app: kubernetes
         role: cloud-controller-manager


### PR DESCRIPTION
/kind cleanup
/platform vsphere

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/422

Ref gardener/gardener#1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
