### PR TITLE
Updated vsphere-csi-driver to 2.4.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: csi-node-driver-registrar
   sourceRepository: https://github.com/kubernetes-csi/node-driver-registrar
   repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-  tag: v2.3.0
+  tag: v2.4.0
 - name: csi-provisioner
   sourceRepository: https://github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner
@@ -24,22 +24,22 @@ images:
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/csi-snapshotter
-  tag: "v3.0.3"
+  tag: v3.0.3
   targetVersion: "< 1.20"
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/csi-snapshotter
-  tag: "v4.2.1"
+  tag: v4.2.1
   targetVersion: ">= 1.20"
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/snapshot-controller
-  tag: "v3.0.3"
+  tag: v3.0.3
   targetVersion: "< 1.20"
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/snapshot-controller
-  tag: "v4.2.1"
+  tag: v4.2.1
   targetVersion: ">= 1.20"
 - name: vsphere-cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-vsphere
@@ -48,26 +48,26 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.43.0"
+  tag: v0.43.0
 - name: machine-controller-manager-provider-vsphere
   sourceRepository: github.com/gardener/machine-controller-manager-provider-vsphere
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-vsphere
-  tag: "v0.11.0"
+  tag: v0.11.0
 - name: vsphere-csi-driver-controller
   #sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   #repository: gcr.io/cloud-provider-vsphere/csi/release/driver
-  #tag: v2.3.0
+  #tag: v2.4.1
   sourceRepository: github.com/MartinWeindel/vsphere-csi-driver
   repository: eu.gcr.io/gardener-project/patches/vsphere-csi-driver/driver
-  tag: v2.3.0-gardener1
+  tag: v2.4.1-gardener1
 - name: vsphere-csi-driver-node
   sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   repository: gcr.io/cloud-provider-vsphere/csi/release/driver
-  tag: v2.3.0
+  tag: v2.4.1
 - name: vsphere-csi-driver-syncer
   sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   repository: gcr.io/cloud-provider-vsphere/csi/release/syncer
-  tag: v2.3.0
+  tag: v2.4.1
 - name: liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: k8s.gcr.io/sig-storage/livenessprobe

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/deployment-vsphere-csi-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/deployment-vsphere-csi-controller.yaml
@@ -35,6 +35,16 @@ spec:
         networking.gardener.cloud/to-private-networks: allowed
         networking.gardener.cloud/to-shoot-apiserver: allowed
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                      - vsphere-csi-controller
+              topologyKey: "kubernetes.io/hostname"
       automountServiceAccountToken: false
       containers:
         - name: csi-attacher
@@ -81,6 +91,7 @@ spec:
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
+            - "--use-gocsi=false"
             - "--kubeconfig=/var/lib/vsphere-csi-controller/kubeconfig"
           env:
             - name: CSI_ENDPOINT

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/service-vsphere-csi-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/service-vsphere-csi-controller.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vsphere-csi-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: vsphere-csi-controller
+spec:
+  ports:
+    - name: ctlr
+      port: 2112
+      targetPort: 2112
+      protocol: TCP
+    - name: syncer
+      port: 2113
+      targetPort: 2113
+      protocol: TCP
+  selector:
+    app: vsphere-csi-controller

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/templates/_helpers.tpl
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/templates/_helpers.tpl
@@ -2,13 +2,6 @@
 [Global]
 cluster-id = "{{ .Values.clusterID }}"
 
-[VirtualCenter "{{ .Values.serverName }}"]
-port = "{{ .Values.serverPort }}"
-datacenters = "{{ .Values.datacenters }}"
-user = "{{ .Values.username }}"
-password = "{{ .Values.password }}"
-insecure-flag = "{{ .Values.insecureFlag }}"
-
 [Labels]
 {{- if .Values.labelRegion }}
 region = "{{ .Values.labelRegion }}"

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/templates/configmap-internal-featurestate.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/templates/configmap-internal-featurestate.yaml
@@ -4,9 +4,11 @@ data:
   "csi-auth-check": "true"
   "online-volume-extend": "true"
   "trigger-csi-fullsync": "false"
-  "async-query-volume": "false"
-  "improved-csi-idempotency": "false"
+  "async-query-volume": "true"
+  "improved-csi-idempotency": "true"
   "block-volume-snapshot": "false"
+  "use-csinode-id": "true"
+  "improved-volume-topology": "true"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
@@ -53,6 +53,7 @@ spec:
         args:
         - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
         - "--fss-namespace=$(CSI_NAMESPACE)"
+        - "--use-gocsi=false"
         env:
         - name: NODE_NAME
           valueFrom:
@@ -61,7 +62,7 @@ spec:
         - name: CSI_ENDPOINT
           value: unix:///csi/csi.sock
         - name: MAX_VOLUMES_PER_NODE
-          value: "0" # Maximum number of volumes that controller can publish to the node. If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
+          value: "59" # Maximum number of volumes that controller can publish to the node. If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
         - name: X_CSI_MODE
           value: "node"
         - name: X_CSI_SPEC_REQ_VALIDATION

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -235,6 +235,7 @@ var controlPlaneChart = &chart.Chart{
 			Objects: []*chart.Object{
 				// csi-driver-controller
 				{Type: &corev1.Secret{}, Name: vsphere.SecretCSIVsphereConfig},
+				{Type: &corev1.Service{}, Name: vsphere.VsphereCSIControllerName},
 				{Type: &appsv1.Deployment{}, Name: vsphere.VsphereCSIControllerName},
 				{Type: &corev1.ConfigMap{}, Name: vsphere.VsphereCSIControllerName + "-observability-config"},
 				{Type: &autoscalingv1beta2.VerticalPodAutoscaler{}, Name: vsphere.VsphereCSIControllerName + "-vpa"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind task
/platform vsphere

**What this PR does / why we need it**:
Updated vsphere-csi-driver dependencies to version 2.4.1.
As the issue [ControllerUnpublishVolume should not fail when the Volume is available](https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/526) is still open, the `vsphere-csi-driver-controller` image is still based on an own fork (see https://github.com/MartinWeindel/vsphere-csi-driver).
Besides the credentials for csi-node on the shoot-cluster have been removed, as they are not needed anymore. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated vsphere-csi-driver dependencies to version 2.4.1.
```
