### PR TITLE
Support for Kubernetes v1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.23 | untested    | not yet available        |
 | Kubernetes 1.22 | untested    | not yet available        |
 | Kubernetes 1.21 | untested    | not yet available        |
 | Kubernetes 1.20 | untested    | not yet available        |

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -119,6 +119,8 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(_ context.Context, _ gcontext.
 }
 
 func ensureKubeletCommandLineArgs(command []string) []string {
+	// TODO: This flag is deprecated and will be removed in future Kubernetes versions. We tried removing it with https://github.com/gardener/gardener-extension-provider-vsphere/pull/201,
+	// however, this led to issues with PVCs. Let's resolve them and remove this flag afterwards.
 	command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
 	return command
 }

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -31,6 +31,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/version"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -103,10 +104,10 @@ func (e *ensurer) ensureChecksumAnnotations(ctx context.Context, template *corev
 }
 
 // EnsureKubeletServiceUnitOptions ensures that the kubelet.service unit options conform to the provider requirements.
-func (e *ensurer) EnsureKubeletServiceUnitOptions(_ context.Context, _ gcontext.GardenContext, _ *semver.Version, new, _ []*unit.UnitOption) ([]*unit.UnitOption, error) {
+func (e *ensurer) EnsureKubeletServiceUnitOptions(_ context.Context, _ gcontext.GardenContext, kubeletVersion *semver.Version, new, _ []*unit.UnitOption) ([]*unit.UnitOption, error) {
 	if opt := extensionswebhook.UnitOptionWithSectionAndName(new, "Service", "ExecStart"); opt != nil {
 		command := extensionswebhook.DeserializeCommandLine(opt.Value)
-		command = ensureKubeletCommandLineArgs(command)
+		command = ensureKubeletCommandLineArgs(command, kubeletVersion)
 		opt.Value = extensionswebhook.SerializeCommandLine(command, 1, " \\\n    ")
 	}
 
@@ -118,8 +119,10 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(_ context.Context, _ gcontext.
 	return new, nil
 }
 
-func ensureKubeletCommandLineArgs(command []string) []string {
-	command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
+func ensureKubeletCommandLineArgs(command []string, kubeletVersion *semver.Version) []string {
+	if !version.ConstraintK8sGreaterEqual123.Check(kubeletVersion) {
+		command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
+	}
 	return command
 }
 

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gardener/gardener-extension-provider-vsphere/pkg/vsphere"
 
+	"github.com/Masterminds/semver"
 	"github.com/coreos/go-systemd/v22/unit"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
@@ -28,6 +29,7 @@ import (
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -241,40 +243,49 @@ var _ = Describe("Ensurer", func() {
 	})
 
 	Describe("#EnsureKubeletServiceUnitOptions", func() {
-		It("should modify existing elements of kubelet.service unit options", func() {
-			var (
-				oldUnitOptions = []*unit.UnitOption{
-					{
-						Section: "Service",
-						Name:    "ExecStart",
-						Value: `/opt/bin/hyperkube kubelet \
+		DescribeTable("should modify existing elements of kubelet.service unit options",
+			func(kubeletVersion *semver.Version, cloudProvider string) {
+				var (
+					oldUnitOptions = []*unit.UnitOption{
+						{
+							Section: "Service",
+							Name:    "ExecStart",
+							Value: `/opt/bin/hyperkube kubelet \
     --config=/var/lib/kubelet/config/kubelet`,
-					},
-				}
-				newUnitOptions = []*unit.UnitOption{
-					{
-						Section: "Service",
-						Name:    "ExecStart",
-						Value: `/opt/bin/hyperkube kubelet \
-    --config=/var/lib/kubelet/config/kubelet \
-    --cloud-provider=external`,
-					},
-					{
-						Section: "Service",
-						Name:    "ExecStartPre",
-						Value:   `/bin/sh -c 'hostnamectl set-hostname $(cat /etc/hostname | cut -d '.' -f 1)'`,
-					},
-				}
-			)
+						},
+					}
+					newUnitOptions = []*unit.UnitOption{
+						{
+							Section: "Service",
+							Name:    "ExecStart",
+							Value: `/opt/bin/hyperkube kubelet \
+    --config=/var/lib/kubelet/config/kubelet`,
+						},
+						{
+							Section: "Service",
+							Name:    "ExecStartPre",
+							Value:   `/bin/sh -c 'hostnamectl set-hostname $(cat /etc/hostname | cut -d '.' -f 1)'`,
+						},
+					}
+				)
 
-			// Create ensurer
-			ensurer := NewEnsurer(logger)
+				if cloudProvider != "" {
+					newUnitOptions[0].Value += ` \
+    --cloud-provider=` + cloudProvider
+				}
 
-			// Call EnsureKubeletServiceUnitOptions method and check the result
-			opts, err := ensurer.EnsureKubeletServiceUnitOptions(context.TODO(), dummyContext, nil, oldUnitOptions, nil)
-			Expect(err).To(Not(HaveOccurred()))
-			Expect(opts).To(Equal(newUnitOptions))
-		})
+				// Create ensurer
+				ensurer := NewEnsurer(logger)
+
+				// Call EnsureKubeletServiceUnitOptions method and check the result
+				opts, err := ensurer.EnsureKubeletServiceUnitOptions(context.TODO(), dummyContext, kubeletVersion, oldUnitOptions, nil)
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(opts).To(Equal(newUnitOptions))
+			},
+
+			Entry("kubelet version < 1.23", semver.MustParse("1.22.0"), "external"),
+			Entry("kubelet version >= 1.23", semver.MustParse("1.23.0"), ""),
+		)
 	})
 
 	Describe("#EnsureKubeletConfiguration", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source usability
/kind enhancement
/platform vsphere
/exp intermediate
/topology garden seed shoot

**What this PR does / why we need it**:
This PR adds support for Kubernetes 1.23 to the extension.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#5102

**Special notes for your reviewer**:
* ✅ ~Depends on #200, hence, PR is in draft state.~
* I have not validated the functionality as follows due to missing test/dev environment:
  * ❔ Create new clusters with versions < 1.23
  * ❔ Create new clusters with version  = 1.23
  * ❔ Upgrade old clusters from version 1.22 to version 1.23
  * ❔ Delete clusters with versions < 1.23
  * ❔ Delete clusters with version  = 1.23

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```feature user
The vSphere extension does now support shoot clusters with Kubernetes version 1.23. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md) before upgrading to 1.23. 
```