### PR TITLE
Updated vsphere-csi-driver images

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -59,21 +59,21 @@ images:
   #tag: v2.4.1
   sourceRepository: github.com/MartinWeindel/vsphere-csi-driver
   repository: eu.gcr.io/gardener-project/patches/vsphere-csi-driver/driver
-  tag: v2.4.1-gardener2
+  tag: v2.4.1-gardener3
 - name: vsphere-csi-driver-node
   #sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   #repository: gcr.io/cloud-provider-vsphere/csi/release/driver
   #tag: v2.4.1
   sourceRepository: github.com/MartinWeindel/vsphere-csi-driver
   repository: eu.gcr.io/gardener-project/patches/vsphere-csi-driver/driver
-  tag: v2.4.1-gardener2
+  tag: v2.4.1-gardener3
 - name: vsphere-csi-driver-syncer
   #sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
   #repository: gcr.io/cloud-provider-vsphere/csi/release/syncer
   #tag: v2.4.1
   sourceRepository: github.com/MartinWeindel/vsphere-csi-driver
   repository: eu.gcr.io/gardener-project/patches/vsphere-csi-driver/syncer
-  tag: v2.4.1-gardener2
+  tag: v2.4.1-gardener3
 - name: liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: k8s.gcr.io/sig-storage/livenessprobe

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -59,15 +59,21 @@ images:
   #tag: v2.4.1
   sourceRepository: github.com/MartinWeindel/vsphere-csi-driver
   repository: eu.gcr.io/gardener-project/patches/vsphere-csi-driver/driver
-  tag: v2.4.1-gardener1
+  tag: v2.4.1-gardener2
 - name: vsphere-csi-driver-node
-  sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
-  repository: gcr.io/cloud-provider-vsphere/csi/release/driver
-  tag: v2.4.1
+  #sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
+  #repository: gcr.io/cloud-provider-vsphere/csi/release/driver
+  #tag: v2.4.1
+  sourceRepository: github.com/MartinWeindel/vsphere-csi-driver
+  repository: eu.gcr.io/gardener-project/patches/vsphere-csi-driver/driver
+  tag: v2.4.1-gardener2
 - name: vsphere-csi-driver-syncer
-  sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
-  repository: gcr.io/cloud-provider-vsphere/csi/release/syncer
-  tag: v2.4.1
+  #sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
+  #repository: gcr.io/cloud-provider-vsphere/csi/release/syncer
+  #tag: v2.4.1
+  sourceRepository: github.com/MartinWeindel/vsphere-csi-driver
+  repository: eu.gcr.io/gardener-project/patches/vsphere-csi-driver/syncer
+  tag: v2.4.1-gardener2
 - name: liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: k8s.gcr.io/sig-storage/livenessprobe


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind technical-debt
/platform vsphere

**What this PR does / why we need it**:
The container images `vsphere-csi-driver-controller` and `vsphere-csi-driver-node` have been replaced with updated build and base images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated vsphere-csi-driver images
```
