### PR TITLE
Add snaphot validation webhook

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -41,6 +41,16 @@ images:
   repository: k8s.gcr.io/sig-storage/snapshot-controller
   tag: v4.2.1
   targetVersion: ">= 1.20"
+- name: csi-snapshot-validation-webhook
+  sourceRepository: github.com/kubernetes-csi/external-snapshotter
+  repository: k8s.gcr.io/sig-storage/snapshot-validation-webhook
+  tag: "v3.0.3"
+  targetVersion: "< 1.20"
+- name: csi-snapshot-validation-webhook
+  sourceRepository: github.com/kubernetes-csi/external-snapshotter
+  repository: k8s.gcr.io/sig-storage/snapshot-validation-webhook
+  tag: "v4.2.1"
+  targetVersion: ">= 1.20"
 - name: vsphere-cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-vsphere
   repository: gcr.io/cloud-provider-vsphere/cpi/release/manager

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/csi-snapshot-validation-webhook-deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/csi-snapshot-validation-webhook-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-snapshot-validation
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: snapshot-validation
+spec:
+  replicas: {{ .Values.csiSnapshotValidationWebhook.replicas }}
+  selector:
+    matchLabels:
+      app: snapshot-validation
+  template:
+    metadata:
+      annotations:
+{{- if .Values.csiSnapshotValidationWebhook.podAnnotations }}
+{{ toYaml .Values.csiSnapshotValidationWebhook.podAnnotations | indent 8 }}
+{{- end }}
+      labels:
+        app: snapshot-validation
+        networking.gardener.cloud/from-shoot-apiserver: allowed
+    spec:
+      containers:
+      - name: csi-snapshot-validation
+        image: {{ index .Values.images "csi-snapshot-validation-webhook" }}
+        imagePullPolicy: IfNotPresent
+        args: ['--tls-cert-file=/etc/csi-snapshot-validation/csi-snapshot-validation.crt', '--tls-private-key-file=etc/csi-snapshot-validation/csi-snapshot-validation.key']
+        ports:
+        - containerPort: 443
+{{- if .Values.csiSnapshotValidationWebhook.resources }}
+        resources:
+{{ toYaml .Values.csiSnapshotValidationWebhook.resources | indent 10 }}
+{{- end }}
+        volumeMounts:
+          - name: csi-snapshot-validation
+            mountPath: /etc/csi-snapshot-validation
+            readOnly: true
+      volumes:
+        - name: csi-snapshot-validation
+          secret:
+            secretName: csi-snapshot-validation

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/csi-snapshot-validation-webhook-networkpolicy.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/csi-snapshot-validation-webhook-networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: snapshot-validation
+    gardener.cloud/role: controlplane
+  name: allow-kube-apiserver-to-csi-snapshot-validation
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    gardener.cloud/description: "Allows Egress from shoot's kube-apiserver pods to csi-snapshot-validation pods."
+spec:
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app: snapshot-validation
+  podSelector:
+    matchLabels:
+      app: kubernetes
+      gardener.cloud/role: controlplane
+      role: apiserver
+  policyTypes:
+  - Egress

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/csi-snapshot-validation-webhook-service.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/csi-snapshot-validation-webhook-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: csi-snapshot-validation
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app: snapshot-validation
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 443

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/csi-snapshot-validation-webhook-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/csi-snapshot-validation-webhook-vpa.yaml
@@ -1,0 +1,17 @@
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: csi-snapshot-webhook-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: csi-snapshot-validation
+      minAllowed:
+        memory: 25Mi
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: csi-snapshot-validation
+  updatePolicy:
+    updateMode: Auto

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/values.yaml
@@ -7,6 +7,7 @@ images:
   vsphere-csi-driver-syncer: image-repository:image-tag
   liveness-probe: image-repository:image-tag
   csi-snapshot-controller: image-repository:image-tag
+  csi-snapshot-validation-webhook: image-repository:image-tag
 
 podAnnotations: {}
 serverName: my.vcenter.server.ip.or.fqdn
@@ -83,6 +84,16 @@ csiSnapshotController:
     limits:
       cpu: 30m
       memory: 50Mi
+
+csiSnapshotValidationWebhook:
+  replica: 1
+  podAnnotations: {}
+  resources:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    cpu: 30m
+    memory: 50Mi
 
 volumesnapshots:
   enabled: false # currently not supported by vsphere-csi-driver

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/templates/csi-snapshot-validation-webhook.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/templates/csi-snapshot-validation-webhook.yaml
@@ -1,0 +1,19 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: csi-snapshot-validation
+webhooks:
+- name: "validation-webhook.snapshot.storage.k8s.io"
+  rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    apiVersions: ["v1", "v1beta1"]
+    operations: ["CREATE", "UPDATE"]
+    resources: ["volumesnapshots", "volumesnapshotcontents"]
+    scope: "*"
+  clientConfig:
+    url: {{ required ".Values.webhookConfig.url is required" .Values.webhookConfig.url }}
+    caBundle: {{ required ".Values.webhookConfig.caBundle is required" .Values.webhookConfig.caBundle | b64enc }}
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  failurePolicy: Fail
+  timeoutSeconds: 10

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/values.yaml
@@ -15,3 +15,10 @@ topologyAware: true
 
 #labelRegion: k8s-region
 #labelZone: k8s-zone
+
+webhookConfig:
+  url: https://service-name.service-namespace/volumesnapshot
+  caBundle: |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----

--- a/pkg/vsphere/types.go
+++ b/pkg/vsphere/types.go
@@ -53,6 +53,8 @@ const (
 	LivenessProbeImageName = "liveness-probe"
 	// CSISnapshotControllerImageName is the name of the csi-snapshot-controller image.
 	CSISnapshotControllerImageName = "csi-snapshot-controller"
+	// CSISnapshotValidationWebhookImageName is the name of the csi-snapshot-validation-webhook image.
+	CSISnapshotValidationWebhookImageName = "csi-snapshot-validation-webhook"
 
 	// Host is a constant for the key in a cloud provider secret holding the VSphere host name
 	Host = "vsphereHost"
@@ -115,6 +117,8 @@ const (
 	CSINodeName = "vsphere-csi-node"
 	// CSIDriverName is a constant for the name of the csi-driver component.
 	CSIDriverName = "csi-driver"
+	// CSISnapshotValidation is the constant for the name of the csi-snapshot-validation-webhook component.
+	CSISnapshotValidation = "csi-snapshot-validation"
 )
 
 var (


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/platform vsphere

**What this PR does / why we need it**:
This PR adds the webhook to provide additional validation to volume snapshot objects i.e. `VolumeSnapshot` and `VolumeSnapshotContent`.

**Which issue(s) this PR fixes**:
Similar to gardener/gardener-extension-provider-aws#507

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The provider-vsphere extension now installs the external-snapshotter's validating webhook server for VolumeSnapshot and VolumeSnapshotContent objects. For more details check the corresponding [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1900-volume-snapshot-validation-webhook#kep-1900-add-additional-validation-to-volume-snapshot-objects).
```
