### PR TITLE
Remove TODO for kubelet's `--cloud-provider` flag

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -119,8 +119,6 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(_ context.Context, _ gcontext.
 }
 
 func ensureKubeletCommandLineArgs(command []string) []string {
-	// TODO: This flag is deprecated and will be removed in future Kubernetes versions. We tried removing it with https://github.com/gardener/gardener-extension-provider-vsphere/pull/201,
-	// however, this led to issues with PVCs. Let's resolve them and remove this flag afterwards.
 	command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
 	return command
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/platform vsphere

**What this PR does / why we need it**:
Even for 1.23 and later, the kubelet's `--cloud-provider` flag seems to be mandatory.

**Special notes for your reviewer**:
See for reference: https://github.com/gardener/gardener-extension-provider-aws/issues/514#issuecomment-1064163827 and https://github.com/gardener/gardener-extension-provider-aws/pull/515

/invite @ialidzhikov

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```
