### PR TITLE
Update/remove csi-snapshot-controller memory/cpu limits. Disable limit autoscaling.

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/vpa-csi-snapshot-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/vpa-csi-snapshot-controller.yaml
@@ -9,6 +9,7 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: csi-snapshot-controller
+      controlledValues: RequestsOnly
       minAllowed:
         memory: 25Mi
   targetRef:

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/values.yaml
@@ -82,8 +82,7 @@ csiSnapshotController:
       cpu: 10m
       memory: 32Mi
     limits:
-      cpu: 30m
-      memory: 50Mi
+      memory: 2.2Gi
 
 csiSnapshotValidationWebhook:
   replica: 1


### PR DESCRIPTION
**How to categorize this PR?**
/area auto-scaling
/area robustness
/kind enhancement
/platform vsphere

**What this PR does / why we need it**:
Improves stability by updating/removing csi-snapshot-controller cpu and memory limits and disabling limit autoscaling.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
Memory limit of csi-snapshot-controller was updated, based on measured usage, to prevent OOMKills due to reaching the limits. Limit scaling was disabled to prevent limit downscaling during periods of load system load. Cpu limit for same component was removed.
```
