### PR TITLE
Upgrade to Golang 1.17.11 to address CVE-2022-29526

### DIFF
--- a/.test-defs/infrastructure-test.yaml
+++ b/.test-defs/infrastructure-test.yaml
@@ -19,4 +19,4 @@ spec:
       --nsxt-t0-gateway="${NSXT_T0_GATEWAY}"
       --nsxt-edge-cluster="${NSXT_EDGE_CLUSTER}"
       --nsxt-snat-ip-pool="${NSXT_SNAT_IP_POOL}"
-  image: golang:1.17.5
+  image: golang:1.17.11

--- a/.test-defs/provider-vsphere.yaml
+++ b/.test-defs/provider-vsphere.yaml
@@ -12,4 +12,4 @@ spec:
       go run -mod=vendor ./test/tm/generator.go
       --infrastructure-provider-config-filepath=$INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
       --controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
-  image: golang:1.17.5
+  image: golang:1.17.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.17.9 AS builder
+FROM golang:1.17.11 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-vsphere
 COPY . .


### PR DESCRIPTION
Signed-off-by: Brian Topping <brian.topping@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/platform vsphere

**What this PR does / why we need it**:
Upgrade to Golang 1.17.11 to address CVE-2022-29526

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Upgrade to Golang 1.17.11
```
