### PR TITLE
Adds MaxAllowed for VPA objects

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/vpa.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/vpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.vpa.enabled }}
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: machine-controller-manager-vpa
@@ -13,8 +13,18 @@ spec:
     updateMode: {{ .Values.vpa.updatePolicy.updateMode | quote }}
   resourcePolicy:
     containerPolicies:
-    - containerName: '*'
+    - containerName: machine-controller-manager-provider-vsphere
       minAllowed:
         cpu: 30m
         memory: 40M
+      maxAllowed:
+        cpu: 2
+        memory: 5G
+    - containerName: vsphere-machine-controller-manager
+      minAllowed:
+        cpu: 30m
+        memory: 40M
+      maxAllowed:
+        cpu: 2
+        memory: 5G
 {{- end }}

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/csi-snapshot-validation-webhook-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/csi-snapshot-validation-webhook-vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: csi-snapshot-webhook-vpa

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/vpa-csi-snapshot-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/vpa-csi-snapshot-controller.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.volumesnapshots.enabled }}
 ---
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: csi-snapshot-controller-vpa

--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/vpa-vsphere-csi-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/vpa-vsphere-csi-controller.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: vsphere-csi-controller-vpa
@@ -7,9 +7,48 @@ metadata:
 spec:
   resourcePolicy:
     containerPolicies:
-      - containerName: '*'
-        minAllowed:
-          memory: 20Mi
+    - containerName: vsphere-csi-controller
+      minAllowed:
+        memory: 20Mi
+      maxAllowed:
+        cpu: 800m
+        memory: 4G
+    - containerName: vsphere-csi-syncer
+      minAllowed:
+        memory: 20Mi
+      maxAllowed:
+        cpu: 500m
+        memory: 3G
+    - containerName: csi-provisioner
+      minAllowed:
+        memory: 20Mi
+      maxAllowed:
+        cpu: 700m
+        memory: 4G
+    - containerName: csi-attacher
+      minAllowed:
+        memory: 20Mi
+      maxAllowed:
+        cpu: 500m
+        memory: 3G
+    - containerName: csi-snapshotter
+      minAllowed:
+        memory: 20Mi
+      maxAllowed:
+        cpu: 500m
+        memory: 2G
+    - containerName: csi-resizer
+      minAllowed:
+        memory: 20Mi
+      maxAllowed:
+        cpu: 500m
+        memory: 2G
+    - containerName: csi-liveness-probe
+      minAllowed:
+        memory: 20Mi
+      maxAllowed:
+        cpu: 500m
+        memory: 2G
   targetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/charts/internal/seed-controlplane/charts/vsphere-cloud-controller-manager/templates/vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/vsphere-cloud-controller-manager/templates/vpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling.k8s.io/v1beta2
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: cloud-controller-manager-vpa
@@ -12,7 +12,10 @@ spec:
     updateMode: Auto
   resourcePolicy:
     containerPolicies:
-    - containerName: '*'
+    - containerName: vsphere-cloud-controller-manager
       minAllowed:
         cpu: 20m
         memory: 40M
+      maxAllowed:
+        cpu: 4
+        memory: 10G


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform vsphere

**What this PR does / why we need it**:
Limits the range of maximum allowed resource requests to ensure that pods are schedulable
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
