### PR TITLE
Upgrade dependencies to latest

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -14,28 +14,13 @@ images:
 - name: csi-provisioner
   sourceRepository: https://github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner
-  tag: v2.2.2
-  targetVersion: "< 1.20"
-- name: csi-provisioner
-  sourceRepository: https://github.com/kubernetes-csi/external-provisioner
-  repository: k8s.gcr.io/sig-storage/csi-provisioner
   tag: v3.1.0
   targetVersion: ">= 1.20"
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/csi-snapshotter
-  tag: v3.0.3
-  targetVersion: "< 1.20"
-- name: csi-snapshotter
-  sourceRepository: github.com/kubernetes-csi/external-snapshotter
-  repository: k8s.gcr.io/sig-storage/csi-snapshotter
   tag: v6.0.1
   targetVersion: ">= 1.20"
-- name: csi-snapshot-controller
-  sourceRepository: github.com/kubernetes-csi/external-snapshotter
-  repository: k8s.gcr.io/sig-storage/snapshot-controller
-  tag: v3.0.3
-  targetVersion: "< 1.20"
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/snapshot-controller
@@ -44,12 +29,7 @@ images:
 - name: csi-snapshot-validation-webhook
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/snapshot-validation-webhook
-  tag: "v3.0.3"
-  targetVersion: "< 1.20"
-- name: csi-snapshot-validation-webhook
-  sourceRepository: github.com/kubernetes-csi/external-snapshotter
-  repository: k8s.gcr.io/sig-storage/snapshot-validation-webhook
-  tag: "v5.0.1"
+  tag: v6.0.1
   targetVersion: ">= 1.20"
 - name: vsphere-cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-vsphere
@@ -58,29 +38,20 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.46.0"
+  tag: v0.46.0
 - name: machine-controller-manager-provider-vsphere
   sourceRepository: github.com/gardener/machine-controller-manager-provider-vsphere
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-vsphere
-  tag: "v0.15.0"
+  tag: v0.16.0
 - name: vsphere-csi-driver-controller
-  #sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
-  #repository: gcr.io/cloud-provider-vsphere/csi/release/driver
-  #tag: v2.4.1
   sourceRepository: github.com/gardener/vsphere-csi-driver
   repository: eu.gcr.io/gardener-project/patches/vsphere-csi-driver/driver
   tag: v2.6.0-gardener2
 - name: vsphere-csi-driver-node
-  #sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
-  #repository: gcr.io/cloud-provider-vsphere/csi/release/driver
-  #tag: v2.4.1
   sourceRepository: github.com/gardener/vsphere-csi-driver
   repository: eu.gcr.io/gardener-project/patches/vsphere-csi-driver/driver
   tag: v2.6.0-gardener2
 - name: vsphere-csi-driver-syncer
-  #sourceRepository: github.com/kubernetes-sigs/vsphere-csi-driver
-  #repository: gcr.io/cloud-provider-vsphere/csi/release/syncer
-  #tag: v2.4.1
   sourceRepository: github.com/gardener/vsphere-csi-driver
   repository: eu.gcr.io/gardener-project/patches/vsphere-csi-driver/syncer
   tag: v2.6.0-gardener2


### PR DESCRIPTION
* Removed pre-1.20 target selectors
* Checked for breaking changes in individual release notes

Signed-off-by: Brian Topping <brian.topping@sap.com>

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: breaking dependency
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Removed support for pre-1.20 Kubernetes target deployments and upgraded container dependencies to latest versions after determining that there were no breaking changes in those dependencies that are likely to cause adverse behavior.
```
