### PR TITLE
Revert "Fix Docforge manifest to accept main branch name change"

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,13 +1,6 @@
-{{- $vers := Split .versions "," -}}
-{{ $defaultBranch := (index $vers 0) }}
 structure:
 - name: _index.md
-  source: https://github.com/gardener/gardener-extension-provider-vsphere/blob/{{$defaultBranch}}/README.md
+  source: /README.md
 - name: docs
-  nodes:
-  - nodesSelector:
-      path: https://github.com/gardener/gardener-extension-provider-vsphere/tree/{{$defaultBranch}}/docs
-links:
-  downloads:
-    scope:
-      "gardener/gardener-extension-provider-vsphere/(blob|raw)/(.*)/docs": ~
+  nodesSelector:
+    path: /docs


### PR DESCRIPTION
Revert "Fix Docforge manifest to accept main branch name change" per request of v.kostov@sap.com.

This reverts commit db141446349c57cda945ea5f0b3817f8a76ef760.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

