### PR TITLE
Vendor gardener `v1.56.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/gardener/etcd-druid v0.12.3
-	github.com/gardener/gardener v1.55.1-0.20220913154745-5d4cd620c96d
+	github.com/gardener/gardener v1.56.0
 	github.com/gardener/machine-controller-manager v0.45.0
 	github.com/go-logr/logr v1.2.3
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/gardener/etcd-druid v0.12.3 h1:FBpsEe+FrBwJ1a2VhaPlXjZsfIAcHGSsF5DvDOcDnbM=
 github.com/gardener/etcd-druid v0.12.3/go.mod h1:EJF6z4Ghv2FGUe1UzZWOEF1MxCA186fxvjBO44oSJX4=
-github.com/gardener/gardener v1.55.1-0.20220913154745-5d4cd620c96d h1:RUgBcW9bazcnnwZhKX1qBAlNcgQAl6htq2PmSnEnreY=
-github.com/gardener/gardener v1.55.1-0.20220913154745-5d4cd620c96d/go.mod h1:Hca1sbJdfOUbdiaU+xd5s1j4IxjsUjv6cQLuhD3OwXs=
+github.com/gardener/gardener v1.56.0 h1:GAs+Nil9bYnGcUJ6rr71SI16pa5Qa1NjXxa6qkpmikg=
+github.com/gardener/gardener v1.56.0/go.mod h1:Hca1sbJdfOUbdiaU+xd5s1j4IxjsUjv6cQLuhD3OwXs=
 github.com/gardener/hvpa-controller/api v0.5.0 h1:f4F3O7YUrenwh4S3TgPREPiB287JjjUiUL18OqPLyAA=
 github.com/gardener/hvpa-controller/api v0.5.0/go.mod h1:QQl3ELkCaki+8RhXl0FZMfvnm0WCGwGJlGmrxJj6lvM=
 github.com/gardener/machine-controller-manager v0.45.0 h1:rpf0PHRXJMGY93oMruNP+tnMawKJXhhzCACyNJsT8Lo=

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -29,6 +29,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -38,7 +39,13 @@ var (
 	defaultSyncPeriod = time.Second * 30
 	// DefaultAddOptions are the default DefaultAddArgs for AddToManager.
 	DefaultAddOptions = healthcheck.DefaultAddArgs{
-		HealthCheckConfig: healthcheckconfig.HealthCheckConfig{SyncPeriod: metav1.Duration{Duration: defaultSyncPeriod}},
+		HealthCheckConfig: healthcheckconfig.HealthCheckConfig{
+			SyncPeriod: metav1.Duration{Duration: defaultSyncPeriod},
+			ShootRESTOptions: &healthcheckconfig.RESTOptions{
+				QPS:   pointer.Float32(100),
+				Burst: pointer.Int(130),
+			},
+		},
 	}
 )
 

--- a/vendor/github.com/gardener/gardener/extensions/pkg/webhook/shoot/shoot.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/webhook/shoot/shoot.go
@@ -17,6 +17,7 @@ package shoot
 import (
 	"fmt"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -43,6 +44,8 @@ type Args struct {
 	Mutator extensionswebhook.Mutator
 	// MutatorWithShootClient is a mutator to be used by the admission handler. It needs the shoot client.
 	MutatorWithShootClient extensionswebhook.MutatorWithShootClient
+	// FailurePolicy is the failure policy for the webhook (defaults to Ignore).
+	FailurePolicy *admissionregistrationv1.FailurePolicyType
 }
 
 // New creates a new webhook with the shoot as target cluster.
@@ -56,11 +59,12 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 	}
 
 	wh := &extensionswebhook.Webhook{
-		Name:     WebhookName,
-		Types:    args.Types,
-		Path:     WebhookName,
-		Target:   extensionswebhook.TargetShoot,
-		Selector: namespaceSelector,
+		Name:          WebhookName,
+		Types:         args.Types,
+		Path:          WebhookName,
+		Target:        extensionswebhook.TargetShoot,
+		Selector:      namespaceSelector,
+		FailurePolicy: args.FailurePolicy,
 	}
 
 	switch {

--- a/vendor/github.com/gardener/gardener/hack/ci-e2e-kind.sh
+++ b/vendor/github.com/gardener/gardener/hack/ci-e2e-kind.sh
@@ -35,7 +35,7 @@ trap "
 make gardener-up
 
 # run test
-make test-e2e-local
+make test-e2e-local PARALLEL_E2E_TESTS=10
 
 # test teardown
 make gardener-down

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/helper.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/helper.go
@@ -526,13 +526,29 @@ func SeedUsesNginxIngressController(seed *gardencorev1beta1.Seed) bool {
 // DetermineMachineImageForName finds the cloud specific machine images in the <cloudProfile> for the given <name> and
 // region. In case it does not find the machine image with the <name>, it returns false. Otherwise, true and the
 // cloud-specific machine image will be returned.
-func DetermineMachineImageForName(cloudProfile *gardencorev1beta1.CloudProfile, name string) (bool, gardencorev1beta1.MachineImage, error) {
+func DetermineMachineImageForName(cloudProfile *gardencorev1beta1.CloudProfile, name string) (bool, gardencorev1beta1.MachineImage) {
 	for _, image := range cloudProfile.Spec.MachineImages {
 		if strings.EqualFold(image.Name, name) {
-			return true, image, nil
+			return true, image
 		}
 	}
-	return false, gardencorev1beta1.MachineImage{}, nil
+	return false, gardencorev1beta1.MachineImage{}
+}
+
+// FindMachineImageVersion finds the machine image version in the <cloudProfile> for the given <name> and <version>.
+// In case no machine image version can be found with the given <name> or <version>, false is being returned.
+func FindMachineImageVersion(cloudProfile *gardencorev1beta1.CloudProfile, name, version string) (bool, gardencorev1beta1.MachineImageVersion) {
+	for _, image := range cloudProfile.Spec.MachineImages {
+		if image.Name == name {
+			for _, imageVersion := range image.Versions {
+				if imageVersion.Version == version {
+					return true, imageVersion
+				}
+			}
+		}
+	}
+
+	return false, gardencorev1beta1.MachineImageVersion{}
 }
 
 // ShootMachineImageVersionExists checks if the shoot machine image (name, version) exists in the machine image constraint and returns true if yes and the index in the versions slice

--- a/vendor/github.com/gardener/gardener/pkg/apis/resources/v1alpha1/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/resources/v1alpha1/types.go
@@ -108,6 +108,10 @@ const (
 	// SeccompProfileSkip is a constant for a label on a Pod which indicates that this Pod should not be considered for
 	// defaulting of its seccomp profile.
 	SeccompProfileSkip = "seccompprofile.resources.gardener.cloud/skip"
+
+	// PodTopologySpreadConstraintsSkip is a constant for a label on a Pod which indicates that this Pod should not be considered for
+	// adding the pod-template-hash selector to the topology spread constraint.
+	PodTopologySpreadConstraintsSkip = "topology-spread-constraints.resources.gardener.cloud/skip"
 )
 
 // +kubebuilder:resource:shortName="mr"

--- a/vendor/github.com/gardener/gardener/pkg/utils/checksums.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/checksums.go
@@ -50,7 +50,7 @@ func ComputeConfigMapChecksum(data map[string]string) string {
 	return computeChecksum(out)
 }
 
-// ComputeChecksum computes a SHA256 checksum for the give map.
+// ComputeChecksum computes a SHA256 checksum for the given data.
 func ComputeChecksum(data interface{}) string {
 	jsonString, err := json.Marshal(data)
 	if err != nil {

--- a/vendor/github.com/gardener/gardener/test/framework/shootmigrationtest.go
+++ b/vendor/github.com/gardener/gardener/test/framework/shootmigrationtest.go
@@ -386,10 +386,11 @@ func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context, mrExclud
 					}
 
 					creationTimestamp := obj.GetCreationTimestamp()
-					log = log.WithValues("objectKind", obj.GetKind(), "objectNamespace", obj.GetNamespace(), "objectName", obj.GetName(), "creationTimestamp", creationTimestamp)
-					log.Info("Found object")
+					objectLog := log.WithValues("objectKind", obj.GetKind(), "objectNamespace", obj.GetNamespace(), "objectName", obj.GetName(), "creationTimestamp", creationTimestamp)
+
+					objectLog.Info("Found object")
 					if t.MigrationTime.Before(&creationTimestamp) {
-						log.Info("Object is created after shoot migration", "migrationTime", t.MigrationTime)
+						objectLog.Info("Object is created after shoot migration", "migrationTime", t.MigrationTime)
 						return fmt.Errorf("object: %s %s/%s Created At: %s is created after the Shoot migration %s", obj.GetKind(), obj.GetNamespace(), obj.GetName(), creationTimestamp, t.MigrationTime)
 					}
 				}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -73,7 +73,7 @@ github.com/fsnotify/fsnotify
 # github.com/gardener/etcd-druid v0.12.3
 ## explicit; go 1.17
 github.com/gardener/etcd-druid/api/v1alpha1
-# github.com/gardener/gardener v1.55.1-0.20220913154745-5d4cd620c96d
+# github.com/gardener/gardener v1.56.0
 ## explicit; go 1.19
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/platform vsphere

**What this PR does / why we need it**:
Vendor gardener `v1.56.0`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following dependency is updated:
- github.com/gardener/gardener: v1.56.0-dev -> v1.56.0
```
