### PR TITLE
Support for Kubernetes v1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support  | Conformance test results |
 |-----------------|----------| -------------------- |
+| Kubernetes 1.25 | untested | not yet available    |
 | Kubernetes 1.24 | untested | not yet available    |
 | Kubernetes 1.23 | untested | not yet available    |
 | Kubernetes 1.22 | untested | not yet available    |

--- a/charts/gardener-extension-provider-vsphere/templates/poddisruptionbudget.yaml
+++ b/charts/gardener-extension-provider-vsphere/templates/poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 {{- if gt (int .Values.replicaCount) 1 }}
+{{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "name" . }}

--- a/charts/gardener-extension-validator-vsphere/charts/runtime/templates/poddisruptionbudget.yaml
+++ b/charts/gardener-extension-validator-vsphere/charts/runtime/templates/poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 {{- if gt (int .Values.global.replicaCount) 1 }}
+{{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "name" . }}

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -34,7 +34,7 @@ images:
 - name: vsphere-cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-vsphere
   repository: gcr.io/cloud-provider-vsphere/cpi/release/manager
-  tag: v1.22.6
+  tag: v1.24.2
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source usability
/kind enhancement
/platform vsphere
/exp intermediate
/topology garden seed shoot
/merge squash

**What this PR does / why we need it**:
This PR adds support for Kubernetes 1.25 to the extension.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6567

**Special notes for your reviewer**:
* ~Depends on #304 , hence, PR is in draft state.~
* ~Depends on `mcm-provider-vsphere` release with https://github.com/gardener/machine-controller-manager-provider-vsphere/pull/42~
* I have successfully validated the functionality as follows:
  * :white_check_mark: Create new clusters with versions < 1.25
  * :white_check_mark: Create new clusters with version  = 1.25
  * :white_check_mark: Upgrade old clusters from version 1.24 to version 1.25
  * :white_check_mark: Delete clusters with versions < 1.25
  * :white_check_mark: Delete clusters with version  = 1.25


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The vsphere extension now supports shoot clusters with Kubernetes version 1.25. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md) before upgrading to 1.25. 
```
