### PR TITLE
Restructure test container to base on `cc/job-image`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -36,7 +36,7 @@ gardener-extension-provider-vsphere:
                     email: 'brian.topping@sap.com'
           gardener-extension-gcve-tm-run:
             registry: 'gcr-readwrite'
-            image: 'eu.gcr.io/gardener-project/gardener/extensions/vsphere-gcve-tm-run'
+            image: 'eu.gcr.io/sap-se-gcr-k8s-private/vsphere-private/vsphere-gcve-tm-run'
             dockerfile: 'Dockerfile'
             target: gardener-extension-gcve-tm-run
             tag_as_latest: true
@@ -83,7 +83,7 @@ gardener-extension-provider-vsphere:
         test-integration:
           trait_depends:
           - publish
-          image: 'eu.gcr.io/gardener-project/gardener/extensions/vsphere-gcve-tm-run:latest'
+          image: 'eu.gcr.io/sap-se-gcr-k8s-private/vsphere-private/vsphere-gcve-tm-run:latest'
     release:
 #      steps:
 #        test-integration:


### PR DESCRIPTION
Signed-off-by: Brian Topping <brian.topping@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind cleanup

**What this PR does / why we need it**:
1. Restructure test container to use `cc/job-image`, eliminating dependency on `debian:11` base image. 
2. Move image repository to `eu.gcr.io/sap-se-gcr-k8s-private/vsphere-private/vsphere-gcve-tm-run` so we can delete the image from the public repositories for now. 

