### PR TITLE
Cleanup build pipelines

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -49,6 +49,7 @@ gardener-extension-provider-vsphere:
           branch: 'master'
       steps:
         test-integration:
+          timeout: "4h"
           trait_depends:
             - publish
           image: 'eu.gcr.io/sap-se-gcr-k8s-private/vsphere-private/vsphere-gcve-tm-run:latest'

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -34,19 +34,6 @@ gardener-extension-provider-vsphere:
                     username: 'briantopping'
                   - type: 'emailAddress'
                     email: 'brian.topping@sap.com'
-          gardener-extension-gcve-tm-run:
-            registry: 'gcr-readwrite'
-            image: 'eu.gcr.io/sap-se-gcr-k8s-private/vsphere-private/vsphere-gcve-tm-run'
-            dockerfile: 'Dockerfile'
-            target: gardener-extension-gcve-tm-run
-            tag_as_latest: true
-            resource_labels:
-              - name: 'cloud.gardener.cnudie/responsibles'
-                value:
-                  - type: 'githubUser'
-                    username: 'briantopping'
-                  - type: 'emailAddress'
-                    email: 'brian.topping@sap.com'
   jobs:
     head-update:
       traits:
@@ -102,3 +89,34 @@ gardener-extension-provider-vsphere:
               channel_name: 'C02DYTGSUNQ' #sap-tech-gardener-on-vmware
               slack_cfg_name: 'scp_workspace'
         component_descriptor: ~
+
+gardener-extension-provider-vsphere-test:
+  template: 'default'
+  base_definition:
+    repo: ~
+    traits:
+      version:
+        preprocess: 'inject-commit-hash'
+        inject_effective_version: true
+  jobs:
+    gcve-test-container:
+      traits:
+        component_descriptor: ~
+        draft_release: ~
+        options:
+          public_build_logs: true
+        publish:
+          dockerimages:
+            gardener-extension-gcve-tm-run:
+              registry: 'gcr-readwrite'
+              image: 'eu.gcr.io/sap-se-gcr-k8s-private/vsphere-private/vsphere-gcve-tm-run'
+              dockerfile: 'Dockerfile'
+              target: gardener-extension-gcve-tm-run
+              tag_as_latest: true
+              resource_labels:
+                - name: 'cloud.gardener.cnudie/responsibles'
+                  value:
+                    - type: 'githubUser'
+                      username: 'briantopping'
+                    - type: 'emailAddress'
+                      email: 'brian.topping@sap.com'

--- a/.ci/terraform/main.tf
+++ b/.ci/terraform/main.tf
@@ -214,10 +214,12 @@ provider "nsxt" {
 resource "nsxt_policy_ip_block" "block1" {
   display_name = "ip-block1"
   cidr         = cidrsubnet(local.privatecloud_cred_obj["privateCloud"]["networkconfig"]["managementcidr"], 5, 2)
+  depends_on   = [google_container_node_pool.primary_nodes]
 }
 
 resource "nsxt_policy_ip_pool" "pool1" {
   display_name = "snat-ippool" # this is used by .ci/terraform/charts/testmachinery-secrets/templates/secrets.yaml
+  depends_on   = [google_container_node_pool.primary_nodes]
 }
 
 resource "nsxt_policy_ip_pool_block_subnet" "block_subnet1" {
@@ -226,4 +228,5 @@ resource "nsxt_policy_ip_pool_block_subnet" "block_subnet1" {
   block_path          = nsxt_policy_ip_block.block1.path
   size                = 8
   auto_assign_gateway = false
+  depends_on          = [google_container_node_pool.primary_nodes]
 }


### PR DESCRIPTION
* Create two separate pipelines to remove the gcve-test container, hopefully this keeps it from getting pulled into the production BOM.
* Set timeout on build to a value that should be sufficient for a complete setup and teardown of GCVE
* Set a Terraform dependency from the NSXT bits to the node pool so the latter is not torn down before the former

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind test
/platform vsphere

**What this PR does / why we need it**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Move the GCVE container to a separate build pipeline so it stays out of the BOM promotion cycle.
```
