### PR TITLE
Fix volume fsType handling for CSI volumes

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-vsphere/templates/deployment-vsphere-csi-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-vsphere/templates/deployment-vsphere-csi-controller.yaml
@@ -194,6 +194,7 @@ spec:
             - "--kube-api-burst=100"
             - "--feature-gates=Topology=true"
             - "--strict-topology"
+            - "--default-fstype=ext4"
             - "--leader-election"
             - "--leader-election-namespace=kube-system"
             - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig


### PR DESCRIPTION
/area storage
/area testing
/kind bug
/platform vsphere

Similar to https://github.com/gardener/gardener-extension-provider-openstack/pull/142

Fixes https://github.com/gardener/gardener-extension-provider-vsphere/issues/368

---
For reference:
- provider-aws - https://github.com/gardener/gardener-extension-provider-aws/blob/907425e071477b973e56f319c43786a43ede67af/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-deployment.yaml#L96
- provider-gcp - https://github.com/gardener/gardener-extension-provider-gcp/blob/b5d19e1f80c2533193db018ae9b962720ae04f83/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller.yaml#L87
- provider-azure - https://github.com/gardener/gardener-extension-provider-azure/blob/de3f182b7e115942c9c4b696923acacc42598e27/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/_deployment.tpl#L118
- provider-openstack - https://github.com/gardener/gardener-extension-provider-openstack/blob/8b5da47d51f8397c476444cdd02c7191ce06eb36/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml#L95
- provider-alicloud - https://github.com/gardener/gardener-extension-provider-alicloud/blob/db405ecc225dda5df8eeca7848a7b1b2ab4981cf/charts/internal/seed-controlplane/charts/csi-alicloud/templates/csi-plugin-controller.yaml#L123

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing CSI PV to do not have set `spec.csi.fsType` is now fixed. The csi-provisioner is now started with `--default-fstype=ext4` which is the default fstype to be used when there is no fstype specified in the StorageClass.
```
