### PR TITLE
Update g/g pull location to upstream release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,7 @@ KIND_ENV                    := "skaffold"
 
 GARDENER_LOCAL_KUBECONFIG   = $(GGARCHIVE)/example/gardener-local/kind/local/kubeconfig
 GGTARBALL                   = /tmp/ggtarball.tgz
-#GGTARBALLURL                = $(shell #curl -s https://api.github.com/repos/gardener/gardener/releases/latest | jq '.tarball_url')
-GGTARBALLURL                = https://codeload.github.com/gardener/gardener/legacy.tar.gz/refs/heads/master
+GGTARBALLURL                = $(shell curl -s https://api.github.com/repos/gardener/gardener/releases/latest | jq '.tarball_url')
 export GGARCHIVE            = /tmp/ggarchive
 
 SHELL=/usr/bin/env bash -o pipefail


### PR DESCRIPTION
Signed-off-by: Brian Topping <brian.topping@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup
/platform vsphere

**What this PR does / why we need it**:
Change the location of upstream gardener content from `master` to the current release. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
