### PR TITLE
Mark vsphere-csi-node as node-critical component

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 metadata:
   name: vsphere-csi-node
   namespace: kube-system
+  labels:
+    node.gardener.cloud/critical-component: "true"
 spec:
   selector:
     matchLabels:
@@ -14,6 +16,7 @@ spec:
       annotations:
         checksum/secret-csi-vsphere-config: {{ include (print $.Template.BasePath "/secret-csi-vsphere-config.yaml") . | sha256sum }}
       labels:
+        node.gardener.cloud/critical-component: "true"
         app: vsphere-csi-node
         role: vsphere-csi
     spec:


### PR DESCRIPTION
**How to categorize this PR?**
/area robustness
/kind enhancement

**What this PR does / why we need it**:

This PR adds the `node.gardener.cloud/critical-component` label to `vsphere-csi-node` DaemonSet introduced in https://github.com/gardener/gardener/pull/7406 

**Which issue(s) this PR fixes**:
Part of  https://github.com/gardener/gardener/issues/7117

**Special notes for your reviewer**:
/hold
until https://github.com/gardener/gardener/pull/7406 is merged

**Release note**:
```feature user
`vsphere-csi-node` is marked as a node-critical component. With this, workload pods are only scheduled to a `Node` if it runs a ready `vsphere-csi-node` pod.
```
