### PR TITLE
Remove the use of the enableBasicAuthentication field

### DIFF
--- a/example/gardener-local/gardener-local-charts/templates/shoot.yaml
+++ b/example/gardener-local/gardener-local-charts/templates/shoot.yaml
@@ -31,7 +31,6 @@ spec:
   kubernetes:
     allowPrivilegedContainers: true
     kubeAPIServer:
-      enableBasicAuthentication: false
       requests:
         maxNonMutatingInflight: 400
         maxMutatingInflight: 200

--- a/test/gcve-setup/gcve-setup.go
+++ b/test/gcve-setup/gcve-setup.go
@@ -243,7 +243,7 @@ func shutdownGCVE(client *http.Client) error {
 		return fmt.Errorf("unexpected response posting to /privateClouds: %d, %s", resp.StatusCode, body)
 	}
 
-	req, err = http.NewRequest("GET", "https://vmwareengine.googleapis.com/v1/"+privateCloudAddr, nil)
+	_, err = http.NewRequest("GET", "https://vmwareengine.googleapis.com/v1/"+privateCloudAddr, nil)
 	if err != nil {
 		return fmt.Errorf("failure to create request: %w", err)
 	}
@@ -466,6 +466,9 @@ func setupIpam(ctx context.Context, client *http.Client) (goipam.Ipamer, error) 
 	}
 
 	_, err = ipam.NewPrefix(ctx, *globalCidr)
+	if err != nil {
+		return nil, err
+	}
 	for _, cloud := range clouds.PrivateClouds {
 		_, err = ipam.AcquireSpecificChildPrefix(ctx, *globalCidr, cloud.NetworkConfig.ManagementCidr)
 		if err != nil {

--- a/test/gcve-setup/test/test.go
+++ b/test/gcve-setup/test/test.go
@@ -45,7 +45,10 @@ func main() {
 		os.Exit(1)
 	}
 	resp, err := conf.Do(req)
-
+	if err != nil {
+		logger.Error(err, "Failure to send request")
+		os.Exit(1)
+	}
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		logger.Error(err, "Could not read from response body")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup
/platform vsphere

**What this PR does / why we need it**:
Removes the use of the enableBasicAuthentication field
Fixes golangci-lint issues

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6911

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
