### PR TITLE
Additional fixes to revert pipeline build. 

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -6,6 +6,8 @@ gardener-extension-provider-vsphere:
       version:
         preprocess: 'inject-commit-hash'
         inject_effective_version: true
+  inherit:
+    publish_template: &publish_anchor
       publish:
         dockerimages:
           gardener-extension-provider-vsphere:
@@ -13,11 +15,25 @@ gardener-extension-provider-vsphere:
             image: 'eu.gcr.io/gardener-project/gardener/extensions/provider-vsphere'
             dockerfile: 'Dockerfile'
             target: gardener-extension-provider-vsphere
+            resource_labels:
+              - name: 'cloud.gardener.cnudie/responsibles'
+                value:
+                  - type: 'githubUser'
+                    username: 'briantopping'
+                  - type: 'emailAddress'
+                    email: 'brian.topping@sap.com'
           gardener-extension-validator-vsphere:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/extensions/validator-vsphere'
             dockerfile: 'Dockerfile'
             target: gardener-extension-validator-vsphere
+            resource_labels:
+              - name: 'cloud.gardener.cnudie/responsibles'
+                value:
+                  - type: 'githubUser'
+                    username: 'briantopping'
+                  - type: 'emailAddress'
+                    email: 'brian.topping@sap.com'
   jobs:
     head-update:
       traits:
@@ -26,6 +42,7 @@ gardener-extension-provider-vsphere:
         draft_release: ~
         options:
           public_build_logs: true
+        <<: *publish_anchor
     pull-request:
       traits:
         pull-request: ~
@@ -35,6 +52,7 @@ gardener-extension-provider-vsphere:
 #       suppress_parallel_execution until we can sort constraints reusing vsphere clusters
         scheduling:
           suppress_parallel_execution: true
+        <<: *publish_anchor
     create-upgrade-prs:
       traits:
         component_descriptor: ~
@@ -42,8 +60,12 @@ gardener-extension-provider-vsphere:
         cronjob:
           interval: '5m'
         update_component_deps: ~
+    scan_artifacts:
+      traits:
+        component_descriptor: ~
     release:
       traits:
+        <<: *publish_anchor
         version:
           preprocess: 'finalize'
         release:
@@ -60,9 +82,3 @@ gardener-extension-provider-vsphere:
               channel_name: 'C02DYTGSUNQ' #sap-tech-gardener-on-vmware
               slack_cfg_name: 'scp_workspace'
         component_descriptor: ~
-        publish:
-          dockerimages:
-            gardener-extension-provider-vsphere:
-              tag_as_latest: true
-            gardener-extension-validator-vsphere:
-              tag_as_latest: true


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup
/platform vsphere

**What this PR does / why we need it**:
Additional fixes to revert pipeline build. Fixes issue with `create-upgrade-prs` creating a new artifact every five minutes, re-adds CNUDIE annotations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
