### PR TITLE
Add wait-for-csi-node annotation to csi-driver-node Pods

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        node.gardener.cloud/wait-for-csi-node-vsphere: csi.vsphere.vmware.com
         checksum/secret-csi-vsphere-config: {{ include (print $.Template.BasePath "/secret-csi-vsphere-config.yaml") . | sha256sum }}
       labels:
         node.gardener.cloud/critical-component: "true"


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind enhancement
/platform vsphere

**What this PR does / why we need it**:

This PR adds the `wait-for-csi-node` annotation to `csi-driver-node` introduced in gardener/gardener#7621

**Which issue(s) this PR fixes**:
Parts of gardener/gardener#7117

**Special notes for your reviewer**:
/hold
until gardener/gardener#7621 is merged

**Release note**:

```feature operator
`vsphere-csi-node` is annotated with the `wait-for-csi-node` annotation. Gardener uses this to only schedule workload pods to a `Node` once the driver has been successfully registered with the `CSINode` object.
```
