### PR TITLE
Change DNS policy for vsphere-csi-node to default

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         role: vsphere-csi
     spec:
       hostNetwork: true
-      dnsPolicy: "ClusterFirstWithHostNet"
+      dnsPolicy: Default
       priorityClassName: system-node-critical
       serviceAccount: csi-driver-node
       tolerations:

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/templates/daemonset.yaml
@@ -87,6 +87,8 @@ spec:
           value: kube-system
         - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
           value: "1"
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ .Values.kubernetesServiceHost }}
         securityContext:
           privileged: true
           capabilities:

--- a/charts/internal/shoot-system-components/charts/csi-vsphere/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-vsphere/values.yaml
@@ -11,6 +11,7 @@ datacenters: dc1
 insecureFlag: true
 # topology-aware setup
 topologyAware: true
+kubernetesServiceHost: kubernetes.example.com
 
 #labelRegion: k8s-region
 #labelZone: k8s-zone

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -345,7 +345,8 @@ insecure-flag = "true"
 					"url":      "https://" + vsphere.CSISnapshotValidation + "." + cp.Namespace + "/volumesnapshot",
 					"caBundle": "",
 				},
-				"pspDisabled": false,
+				"pspDisabled":           false,
+				"kubernetesServiceHost": "api.foo.test.com",
 			},
 		}
 
@@ -400,6 +401,11 @@ insecure-flag = "true"
 						ControlPlaneConfig: &runtime.RawExtension{
 							Raw: encode(cpConfig),
 						},
+					},
+				},
+				Status: gardencorev1beta1.ShootStatus{
+					AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{
+						{Name: "internal", URL: "https://api.foo.test.com"},
 					},
 				},
 			},
@@ -536,7 +542,8 @@ insecure-flag = "true"
 							"url":      "https://" + vsphere.CSISnapshotValidation + "." + cp.Namespace + "/volumesnapshot",
 							"caBundle": "",
 						},
-						"pspDisabled": false,
+						"pspDisabled":           false,
+						"kubernetesServiceHost": "api.foo.test.com",
 					},
 				}
 
@@ -573,7 +580,8 @@ insecure-flag = "true"
 							"url":      "https://" + vsphere.CSISnapshotValidation + "." + cp.Namespace + "/volumesnapshot",
 							"caBundle": "",
 						},
-						"pspDisabled": true,
+						"pspDisabled":           true,
+						"kubernetesServiceHost": "api.foo.test.com",
 					},
 				}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind impediment
/platform vsphere

**What this PR does / why we need it**:
With the introduction of the feature [Wait for node-critical pods before scheduling workload pods](https://github.com/gardener/gardener/issues/7117) a deadlock was introduced for the vsphere-csi-node startup on new clusters.
The `vsphere-csi-node` tries to get the config map `internal-feature-states.csi.vsphere.vmware.com` from the kube-apiserver, but the DNS resolution fails, as the CoreDNS pods are still pending. They are waiting for the node taint `node.gardener.cloud/critical-components-not-ready` with effect `NoSchedule` is removed. But as the vsphere-csi-node is not ready, the taint is not removed.
The easy solution to resolve the deadlock is to change the DNS policy to "Default". As the vsphere-csi-node is running in the host network, the DNS resolution of the kube-apiserver name is performed by the node then.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Just for reference, here the error message in the vsphere-csi-node:
```txt
{"level":"error","time":"2023-03-29T15:39:37.394823348Z","caller":"k8sorchestrator/k8sorchestrator.go:364","msg":"failed to fetch configmap internal-feature-states.csi.vsphere.vmware.com from namespace kube-system. Error: Get \"https://api.bmahjo3yg1.xxx.internal.example.com:443/api/v1/namespaces/kube-system/configmaps/internal-feature-states.csi.vsphere.vmware.com\": dial tcp: lookup api.bmahjo3yg1.ixxx.internal.example.com on 100.104.0.10:53: write udp 100.104.0.10:51734->100.104.0.10:53: write: operation not permitted","TraceId":"0d9eca11-2214-49be-9bb6-f1e0802e2e14","TraceId":"1c0b19db-c25f-409e-9c47-fe3d67d716d7","stacktrace":"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator.initFSS\n\t/build/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:364\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco/k8sorchestrator.Newk8sOrchestrator\n\t/build/pkg/csi/service/common/commonco/k8sorchestrator/k8sorchestrator.go:265\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common/commonco.GetContainerOrchestratorInterface\n\t/build/pkg/csi/service/common/commonco/coagnostic.go:81\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service.(*vsphereCSIDriver).BeforeServe\n\t/build/pkg/csi/service/driver.go:114\nsigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service.(*vsphereCSIDriver).Run\n\t/build/pkg/csi/service/driver.go:151\nmain.main\n\t/build/cmd/vsphere-csi/main.go:71\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250"}
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Change DNS policy for vsphere-csi-node to default
```
