### PR TITLE
Support for Kubernetes v1.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support  | Conformance test results |
 |-----------------|----------| -------------------- |
+| Kubernetes 1.27 | untested | not yet available    |
 | Kubernetes 1.26 | untested | not yet available    |
 | Kubernetes 1.25 | untested | not yet available    |
 | Kubernetes 1.24 | untested | not yet available    |


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source usability
/kind enhancement
/platform vsphere
/exp intermediate
/topology garden seed shoot
/merge squash

**What this PR does / why we need it**:
This PR adds support for Kubernetes 1.27 to the extension.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7783

**Special notes for your reviewer**:
* I have successfully validated the functionality as follows:
  * Create new clusters with versions < 1.27
  * Create new clusters with version  = 1.27
  * Upgrade old clusters from version 1.26 to version 1.27
  * Delete clusters with versions < 1.27
  * Delete clusters with version  = 1.27


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The vsphere extension now supports shoot clusters with Kubernetes version 1.27. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md) before upgrading to 1.27. 
```
