### PR TITLE
Drop code related to `APIServerSNI` feature gate

### DIFF
--- a/pkg/webhook/controlplaneexposure/ensurer_test.go
+++ b/pkg/webhook/controlplaneexposure/ensurer_test.go
@@ -16,34 +16,20 @@ package controlplaneexposure
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 
 	"github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/config"
-)
-
-const (
-	namespace = "test"
 )
 
 func TestController(t *testing.T) {
@@ -58,28 +44,8 @@ var _ = Describe("Ensurer", func() {
 			Capacity:  utils.QuantityPtr(resource.MustParse("80Gi")),
 		}
 
-		ctrl *gomock.Controller
-
+		ctrl         *gomock.Controller
 		dummyContext = gcontext.NewGardenContext(nil, nil)
-
-		svcKey = client.ObjectKey{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}
-		svc    = &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: namespace},
-			Status: corev1.ServiceStatus{
-				LoadBalancer: corev1.LoadBalancerStatus{
-					Ingress: []corev1.LoadBalancerIngress{
-						{IP: "1.2.3.4"},
-					},
-				},
-			},
-		}
-		cluster = &extensionsv1alpha1.Cluster{
-			Spec: extensionsv1alpha1.ClusterSpec{
-				Shoot: runtime.RawExtension{
-					Raw: encode(&gardencorev1beta1.Shoot{}),
-				},
-			},
-		}
 	)
 
 	BeforeEach(func() {
@@ -88,119 +54,6 @@ var _ = Describe("Ensurer", func() {
 
 	AfterEach(func() {
 		ctrl.Finish()
-	})
-
-	Describe("#EnsureKubeAPIServerDeployment", func() {
-		It("should not modify kube-apiserver deployment if SNI is enabled", func() {
-			var (
-				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      v1beta1constants.DeploymentNameKubeAPIServer,
-						Namespace: namespace,
-						Labels:    map[string]string{"core.gardener.cloud/apiserver-exposure": "gardener-managed"},
-					},
-					Spec: appsv1.DeploymentSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name: "kube-apiserver",
-									},
-								},
-							},
-						},
-					},
-				}
-				depCopy = dep.DeepCopy()
-			)
-
-			// Create ensurer
-			ensurer := NewEnsurer(etcdStorage, logger)
-
-			err := ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep, nil)
-			Expect(err).To(Not(HaveOccurred()))
-
-			Expect(dep).To(Equal(depCopy))
-		})
-
-		It("should add missing elements to kube-apiserver deployment", func() {
-			var (
-				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: namespace},
-					Spec: appsv1.DeploymentSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name: "kube-apiserver",
-									},
-								},
-							},
-						},
-					},
-				}
-			)
-
-			// Create mock client
-			c := mockclient.NewMockClient(ctrl)
-			c.EXPECT().Get(context.TODO(), client.ObjectKey{Name: namespace}, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(cluster))
-			c.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespace,
-					Name:      v1beta1constants.DeploymentNameKubeAPIServer,
-				},
-			}).DoAndReturn(clientGet(svc))
-
-			// Create ensurer
-			ensurer := NewEnsurer(etcdStorage, logger)
-			err := ensurer.(inject.Client).InjectClient(c)
-			Expect(err).To(Not(HaveOccurred()))
-
-			// Call EnsureKubeAPIServerDeployment method and check the result
-			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep, nil)
-			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep)
-		})
-
-		It("should modify existing elements of kube-apiserver deployment", func() {
-			var (
-				dep = &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: namespace},
-					Spec: appsv1.DeploymentSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name:    "kube-apiserver",
-										Command: []string{"--advertise-address=?", "--external-hostname=?"},
-									},
-								},
-							},
-						},
-					},
-				}
-			)
-
-			// Create mock client
-			c := mockclient.NewMockClient(ctrl)
-			c.EXPECT().Get(context.TODO(), client.ObjectKey{Name: namespace}, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(cluster))
-			c.EXPECT().Get(context.TODO(), svcKey, &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespace,
-					Name:      v1beta1constants.DeploymentNameKubeAPIServer,
-				},
-			}).DoAndReturn(clientGet(svc))
-
-			// Create ensurer
-			ensurer := NewEnsurer(etcdStorage, logger)
-			err := ensurer.(inject.Client).InjectClient(c)
-			Expect(err).To(Not(HaveOccurred()))
-
-			// Call EnsureKubeAPIServerDeployment method and check the result
-			err = ensurer.EnsureKubeAPIServerDeployment(context.TODO(), dummyContext, dep, nil)
-			Expect(err).To(Not(HaveOccurred()))
-			checkKubeAPIServerDeployment(dep)
-		})
 	})
 
 	Describe("#EnsureETCD", func() {
@@ -278,14 +131,6 @@ var _ = Describe("Ensurer", func() {
 	})
 })
 
-func checkKubeAPIServerDeployment(dep *appsv1.Deployment) {
-	// Check that the kube-apiserver container still exists and contains all needed command line args
-	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-apiserver")
-	Expect(c).To(Not(BeNil()))
-	Expect(c.Command).To(ContainElement("--advertise-address=1.2.3.4"))
-	Expect(c.Command).To(ContainElement("--external-hostname=1.2.3.4"))
-}
-
 func checkETCDMain(etcd *druidv1alpha1.Etcd) {
 	Expect(*etcd.Spec.StorageClass).To(Equal("gardener.cloud-fast"))
 	Expect(*etcd.Spec.StorageCapacity).To(Equal(resource.MustParse("80Gi")))
@@ -294,21 +139,4 @@ func checkETCDMain(etcd *druidv1alpha1.Etcd) {
 func checkETCDEvents(etcd *druidv1alpha1.Etcd) {
 	Expect(*etcd.Spec.StorageClass).To(Equal(""))
 	Expect(*etcd.Spec.StorageCapacity).To(Equal(resource.MustParse("10Gi")))
-}
-
-func clientGet(result runtime.Object) interface{} {
-	return func(ctx context.Context, key client.ObjectKey, obj runtime.Object, _ ...client.GetOption) error {
-		switch obj.(type) {
-		case *corev1.Service:
-			*obj.(*corev1.Service) = *result.(*corev1.Service)
-		case *extensionsv1alpha1.Cluster:
-			*obj.(*extensionsv1alpha1.Cluster) = *result.(*extensionsv1alpha1.Cluster)
-		}
-		return nil
-	}
-}
-
-func encode(obj runtime.Object) []byte {
-	data, _ := json.Marshal(obj)
-	return data
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
This PR removes all code related to the removed `APIServerSNI` feature gate of `gardenlet` since it is no longer relevant now (it wasn't relevant for a long time already since the feature gate was locked to "enabled").

**Special notes for your reviewer**:
Related to https://github.com/gardener/gardener/pull/8062

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
All code related to the removed `APIServerSNI` feature gate of `gardenlet` has been removed from this extension.
```