### PR TITLE
Copy 98cd8533, removed sfz forbidding validation (gardener/gardener-extension-provider-gcp#433)

### DIFF
--- a/pkg/apis/vsphere/validation/shoot.go
+++ b/pkg/apis/vsphere/validation/shoot.go
@@ -67,10 +67,6 @@ func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList
 			continue
 		}
 
-		if worker.Maximum != 0 && worker.Minimum == 0 {
-			allErrs = append(allErrs, field.Forbidden(workerFldPath.Child("minimum"), "minimum value must be >= 1 if maximum value > 0 (auto scaling to 0 is not supported)"))
-		}
-
 		zones := sets.NewString()
 		for j, zone := range worker.Zones {
 			if zones.Has(zone) {

--- a/pkg/apis/vsphere/validation/shoot_test.go
+++ b/pkg/apis/vsphere/validation/shoot_test.go
@@ -161,19 +161,6 @@ var _ = Describe("Shoot validation", func() {
 					})),
 				))
 			})
-
-			It("should enforce workers min > 0 if max > 0", func() {
-				workers[0].Minimum = 0
-
-				errorList := ValidateWorkers(workers, nilPath)
-
-				Expect(errorList).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeForbidden),
-						"Field": Equal("[0].minimum"),
-					})),
-				))
-			})
 		})
 
 		Describe("#ValidateWorkersUpdate", func() {


### PR DESCRIPTION
Remove validation that was removed from GCP project. Copies gardener/gardener-extension-provider-gcp#433.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area auto-scaling
/kind cleanup
/platform vsphere

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Remove validator restriction on scaling to zero
```
