### PR TITLE
Upgrade v1beta2 vpa resource to v1

### DIFF
--- a/charts/gardener-extension-provider-vsphere/templates/vpa.yaml
+++ b/charts/gardener-extension-provider-vsphere/templates/vpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.vpa.enabled}}
-apiVersion: "autoscaling.k8s.io/v1beta2"
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "name" . }}-vpa

--- a/charts/gardener-extension-validator-vsphere/charts/runtime/templates/vpa.yaml
+++ b/charts/gardener-extension-validator-vsphere/charts/runtime/templates/vpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.vpa.enabled}}
-apiVersion: "autoscaling.k8s.io/v1beta2"
+apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "name" . }}-vpa

--- a/cmd/provider-vsphere/app/app.go
+++ b/cmd/provider-vsphere/app/app.go
@@ -34,7 +34,7 @@ import (
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	autoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -171,7 +171,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			if err := machinev1alpha1.AddToScheme(scheme); err != nil {
 				return fmt.Errorf("could not update manager scheme: %w", err)
 			}
-			if err := autoscalingv1beta2.AddToScheme(scheme); err != nil {
+			if err := autoscalingv1.AddToScheme(scheme); err != nil {
 				return fmt.Errorf("could not update manager scheme: %w", err)
 			}
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -50,7 +50,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	autoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 
 	apisvsphere "github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/vsphere"
 	"github.com/gardener/gardener-extension-provider-vsphere/pkg/apis/vsphere/helper"
@@ -136,7 +136,7 @@ var controlPlaneChart = &chart.Chart{
 				{Type: &corev1.Service{}, Name: vsphere.CloudControllerManagerName},
 				{Type: &appsv1.Deployment{}, Name: vsphere.CloudControllerManagerName},
 				{Type: &corev1.ConfigMap{}, Name: vsphere.CloudControllerManagerName + "-observability-config"},
-				{Type: &autoscalingv1beta2.VerticalPodAutoscaler{}, Name: vsphere.CloudControllerManagerName + "-vpa"},
+				{Type: &autoscalingv1.VerticalPodAutoscaler{}, Name: vsphere.CloudControllerManagerName + "-vpa"},
 			},
 		},
 		{
@@ -158,10 +158,10 @@ var controlPlaneChart = &chart.Chart{
 				{Type: &corev1.Service{}, Name: vsphere.VsphereCSIControllerName},
 				{Type: &appsv1.Deployment{}, Name: vsphere.VsphereCSIControllerName},
 				{Type: &corev1.ConfigMap{}, Name: vsphere.VsphereCSIControllerName + "-observability-config"},
-				{Type: &autoscalingv1beta2.VerticalPodAutoscaler{}, Name: vsphere.VsphereCSIControllerName + "-vpa"},
+				{Type: &autoscalingv1.VerticalPodAutoscaler{}, Name: vsphere.VsphereCSIControllerName + "-vpa"},
 				// csi-snapshot-controller
 				{Type: &appsv1.Deployment{}, Name: vsphere.CSISnapshotControllerName},
-				{Type: &autoscalingv1beta2.VerticalPodAutoscaler{}, Name: vsphere.CSISnapshotControllerName + "-vpa"},
+				{Type: &autoscalingv1.VerticalPodAutoscaler{}, Name: vsphere.CSISnapshotControllerName + "-vpa"},
 				// csi-snapshot-validation-webhook
 				{Type: &appsv1.Deployment{}, Name: vsphere.CSISnapshotValidation},
 				{Type: &corev1.Service{}, Name: vsphere.CSISnapshotValidation},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance
/kind api-change
/platform vsphere

**What this PR does / why we need it**:

During the deployment, the following deprecation warning was observed:
```
W0810 16:41:29.620111   11438 warnings.go:70] autoscaling.k8s.io/v1beta2 API is deprecated
```

Similar to: https://github.com/gardener/gardener-extension-provider-aws/pull/527/commits/5c0592efed7c5d0a23f1d66a876aa4f07d158790

I haven't tested the change.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Upgrade v1beta2 vpa resource to v1 for vsphere
```
