### PR TITLE
Fix the type of the network policy port

### DIFF
--- a/charts/internal/seed-controlplane/charts/vsphere-cloud-controller-manager/templates/cloud-controller-manager-svc.yaml
+++ b/charts/internal/seed-controlplane/charts/vsphere-cloud-controller-manager/templates/cloud-controller-manager-svc.yaml
@@ -7,10 +7,10 @@ metadata:
     app: kubernetes
     role: cloud-controller-manager
   annotations:
-    networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":10258,"protocol":"TCP"}]'
+    networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":"10258","protocol":"TCP"}]'
     # TODO: This label approach is deprecated and no longer needed in the future. Remove them as soon as gardener/gardener@v1.75 has been released.
     networking.resources.gardener.cloud/from-policy-pod-label-selector: all-scrape-targets
-    networking.resources.gardener.cloud/from-policy-allowed-ports: '[{"port":10258,"protocol":"TCP"}]'
+    networking.resources.gardener.cloud/from-policy-allowed-ports: '[{"port":"10258","protocol":"TCP"}]'
 spec:
   type: ClusterIP
   clusterIP: None


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform vsphere

**What this PR does / why we need it**:

The networking annotations (see [doc][]) of the `cloud-controller-manager` service

```
networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":"10258","protocol":"TCP"}]'

networking.resources.gardener.cloud/from-policy-allowed-ports: '[{"port":"10258","protocol":"TCP"}]'
networking.resources.gardener.cloud/from-policy-pod-label-selector: all-scrape-targets
```

contain the port number as a string, as introduced in [PR 411][] and [PR 383][], probably as a typo.

Although a string port can be [parsed][] into the `NetworkPolicyPort` [struct][] which expects an `IntOrString`, the validation of the resulting `NetworkPolicy` in the kubernetes API server [fails][] in the `IsValidPortName` [method][]. If the port is a string, it is expected to be a port name, otherwise it should be a number.

When the validation fails, the generated network policies

```
 egress-to-cloud-controller-manager-tcp-10258-via-all-scrape-targets
ingress-to-cloud-controller-manager-tcp-10258-via-all-scrape-targets
```

can not be created, and hence the control plane Prometheus can not scrape the `cloud-controller-manager` pods, which leads to the `CloudControllerManagerDown` [alerts][].

The fix is to use a number for the port value.

[doc]: https://github.com/gardener/gardener/blob/c0419b0e281afcf590afa08c6e845170ec2962c4/docs/concepts/resource-manager.md#networkpolicy-controller
[PR 411]: https://github.com/gardener/gardener-extension-provider-vsphere/pull/411/files#diff-565227090de1b0d3200de25fe9755ea687560f468cf9e6df76a8d4b7d59361e5R10
[PR 383]: https://github.com/gardener/gardener-extension-provider-vsphere/pull/383/files#diff-565227090de1b0d3200de25fe9755ea687560f468cf9e6df76a8d4b7d59361e5R11
[parsed]: https://github.com/gardener/gardener/blob/c0419b0e281afcf590afa08c6e845170ec2962c4/pkg/resourcemanager/controller/networkpolicy/reconciler.go#L227-L238
[struct]: https://github.com/gardener/gardener/blob/c0419b0e281afcf590afa08c6e845170ec2962c4/vendor/k8s.io/api/networking/v1/types.go#L144-L155
[fails]: https://github.com/kubernetes/kubernetes/blob/e298e92115439916320eed0dee26b7c4d8d9a5f6/pkg/apis/networking/validation/validation.go#L76-L92
[method]: https://github.com/kubernetes/kubernetes/blob/419df231bcb8c926deab4f5c1c1a77c94866bb16/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L334
[alerts]: https://github.com/gardener/gardener-extension-provider-vsphere/blob/5559e6fa80728d9906b2de2f49dc1f0d9b25b2f3/charts/internal/seed-controlplane/charts/vsphere-cloud-controller-manager/templates/configmap-observability.yaml#L43

**Which issue(s) this PR fixes**:
Fixes a "typo" introduced in #411 and #383.

**Special notes for your reviewer**:

/cc @ScheererJ @rickardsjp @briantopping

Similar to https://github.com/gardener/gardener-extension-provider-alicloud/pull/637

Note: I confirmed in an existing dev shoot that the network policies are created as expected if the annotation uses the port number, but I haven't performed an end-to-end test e.g. with the [getting_started_locally_with_extensions.md](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally_with_extensions.md) setup.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug related to the network policy annotations that prevented the shoot control plane Prometheus from scraping the `cloud-controller-manager` and caused false alerts is fixed.
```
