### PR TITLE
Fix NPEs in shoot and secret validators

### DIFF
--- a/cmd/validator-vsphere/app/app.go
+++ b/cmd/validator-vsphere/app/app.go
@@ -94,8 +94,8 @@ func NewValidatorCommand(ctx context.Context) *cobra.Command {
 			hookServer := mgr.GetWebhookServer()
 
 			log.Info("Registering webhooks")
-			hookServer.Register("/webhooks/validate", &webhook.Admission{Handler: &validator.Shoot{Logger: log.WithName("shoot-validator")}})
-			hookServer.Register("/webhooks/validate/secrets", &webhook.Admission{Handler: &validator.Secret{Logger: log.WithName("secret-validator")}})
+			hookServer.Register("/webhooks/validate", &webhook.Admission{Handler: validator.NewShootHandler(mgr, log)})
+			hookServer.Register("/webhooks/validate/secrets", &webhook.Admission{Handler: validator.NewSecretHandler(mgr, log)})
 
 			if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {
 				return fmt.Errorf("could not add readycheck for informers: %w", err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform vsphere

**What this PR does / why we need it**:
The gardener-extension-validator-vsphere panics because of uninitialized shoot and secret validators.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix NPEs in shoot and secret validators of `gardener-extension-validator-vsphere`
```
