### PR TITLE
CSI topology labels on MachineDeployment supporting scale from zero

### DIFF
--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -400,6 +400,8 @@ var _ = Describe("Machines", func() {
 				err = workerDelegate.UpdateMachineImagesStatus(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
+				labelsZone1 := map[string]string{vsphere.CSITopologyRegionKey: region, vsphere.CSITopologyZoneKey: zone1}
+				labelsZone2 := map[string]string{vsphere.CSITopologyRegionKey: region, vsphere.CSITopologyZoneKey: zone2}
 				// Test workerDelegate.GenerateMachineDeployments()
 				machineDeployments := worker.MachineDeployments{
 					{
@@ -410,6 +412,7 @@ var _ = Describe("Machines", func() {
 						Maximum:              worker.DistributeOverZones(0, maxPool1, 2),
 						MaxSurge:             worker.DistributePositiveIntOrPercent(0, maxSurgePool1, 2, maxPool1),
 						MaxUnavailable:       worker.DistributePositiveIntOrPercent(0, maxUnavailablePool1, 2, minPool1),
+						Labels:               labelsZone1,
 						MachineConfiguration: machineConfiguration,
 					},
 					{
@@ -420,6 +423,7 @@ var _ = Describe("Machines", func() {
 						Maximum:              worker.DistributeOverZones(1, maxPool1, 2),
 						MaxSurge:             worker.DistributePositiveIntOrPercent(1, maxSurgePool1, 2, maxPool1),
 						MaxUnavailable:       worker.DistributePositiveIntOrPercent(1, maxUnavailablePool1, 2, minPool1),
+						Labels:               labelsZone2,
 						MachineConfiguration: machineConfiguration,
 					},
 					{
@@ -430,6 +434,7 @@ var _ = Describe("Machines", func() {
 						Maximum:              worker.DistributeOverZones(0, maxPool2, 2),
 						MaxSurge:             worker.DistributePositiveIntOrPercent(0, maxSurgePool2, 2, maxPool1),
 						MaxUnavailable:       worker.DistributePositiveIntOrPercent(0, maxUnavailablePool2, 2, minPool1),
+						Labels:               labelsZone1,
 						MachineConfiguration: machineConfiguration,
 					},
 					{
@@ -440,6 +445,7 @@ var _ = Describe("Machines", func() {
 						Maximum:              worker.DistributeOverZones(1, maxPool2, 2),
 						MaxSurge:             worker.DistributePositiveIntOrPercent(1, maxSurgePool2, 2, maxPool1),
 						MaxUnavailable:       worker.DistributePositiveIntOrPercent(1, maxUnavailablePool2, 2, minPool1),
+						Labels:               labelsZone2,
 						MachineConfiguration: machineConfiguration,
 					},
 				}

--- a/pkg/vsphere/types.go
+++ b/pkg/vsphere/types.go
@@ -35,6 +35,15 @@ const (
 
 	// CSIAttacherImageName is the name of the CSI attacher image.
 	CSIAttacherImageName = "csi-attacher"
+	// CSITopologyLabelsDomain is the domain name used to identify  topology labels applied on the node by vSphere CSI driver.
+	// See [VSphere CSI Driver Config]
+	//
+	// [VSphere CSI Driver Config]: https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/a14797738b474d331af96a62783ec94e1c24f53e/pkg/common/config/config.go#L87
+	CSITopologyLabelsDomain = "topology.csi.vmware.com"
+	// CSITopologyRegionKey is the topology key denoting the region.
+	CSITopologyRegionKey = CSITopologyLabelsDomain + "/" + "k8s-region"
+	// CSITopologyZoneKey is the topology key denoting the zone.
+	CSITopologyZoneKey = CSITopologyLabelsDomain + "/" + "k8s-zone"
 	// CSINodeDriverRegistrarImageName is the name of the CSI driver registrar image.
 	CSINodeDriverRegistrarImageName = "csi-node-driver-registrar"
 	// CSIProvisionerImageName is the name of the CSI provisioner image.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform vsphere

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/autoscaler/issues/245

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
MachineDeployments will have the CSI topology labels `topology.csi.vmware.com/k8s-region` and `topology.csi.vmware.com/k8s-zone` when created.
```
