### PR TITLE
Drop support for Shoots with Kubernetes version < 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.26 | 1.26.0+ | [![Gardener v1.26 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.26%20vSphere/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.26%20vSphere) |
 | Kubernetes 1.25 | 1.25.0+ | [![Gardener v1.25 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.25%20vSphere/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.25%20vSphere) |
 | Kubernetes 1.24 | 1.24.0+ | [![Gardener v1.24 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.24%20vSphere/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.24%20vSphere) |
-| Kubernetes 1.23 | 1.23.0+ | [![Gardener v1.23 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.23%20vSphere/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.23%20vSphere) |
-| Kubernetes 1.22 | 1.22.0+ | [![Gardener v1.22 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.22%20vSphere/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.22%20vSphere) |
 
 Older versions of the extension [(`v0.16.0` and earlier)](https://github.com/gardener/gardener-extension-provider-vsphere/releases/tag/v0.16.0) are supported prior to current releases.
 

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -42,7 +42,7 @@ images:
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: registry.k8s.io/sig-storage/csi-provisioner
   tag: v3.5.0
-  targetVersion: ">= 1.22"
+  targetVersion: ">= 1.24"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -56,7 +56,7 @@ images:
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/csi-snapshotter
   tag: v6.2.2
-  targetVersion: ">= 1.22"
+  targetVersion: ">= 1.24"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -70,7 +70,7 @@ images:
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/snapshot-controller
   tag: v6.2.2
-  targetVersion: ">= 1.22"
+  targetVersion: ">= 1.24"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -84,7 +84,7 @@ images:
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/snapshot-validation-webhook
   tag: v6.2.2
-  targetVersion: ">= 1.22"
+  targetVersion: ">= 1.24"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -150,9 +150,9 @@ spec:
         guestId: other4xLinux64Guest
   kubernetes:
     versions:
-    - version: 1.23.4
-    - version: 1.24.0
-    - version: 1.24.1
+    - version: 1.27.4
+    - version: 1.26.0
+    - version: 1.25.1
   machineImages:
   - name: flatcar
     versions:
@@ -182,7 +182,7 @@ spec:
 
 ## Which versions of Kubernetes/vSphere are supported
 
-This extension targets Kubernetes >= `v1.22` and vSphere `6.7 U3` or later.
+This extension targets Kubernetes >= `v1.24` and vSphere `6.7 U3` or later.
 
 - vSphere CSI driver needs vSphere `6.7 U3` or later,
   and Kubernetes >= `v1.16`

--- a/example/gardener-local/gardener-local-charts/templates/shoot.yaml
+++ b/example/gardener-local/gardener-local-charts/templates/shoot.yaml
@@ -54,7 +54,7 @@ spec:
       imageGCHighThresholdPercent: 50
       imageGCLowThresholdPercent: 40
       serializeImagePulls: true
-    version: 1.23.13
+    version: 1.26.6
     verticalPodAutoscaler:
       enabled: false
       evictAfterOOMThreshold: 10m0s

--- a/pkg/apis/vsphere/validation/controlplane_test.go
+++ b/pkg/apis/vsphere/validation/controlplane_test.go
@@ -80,7 +80,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 				},
 			}
 
-			errorList := ValidateControlPlaneConfig(controlPlane, "1.23.14", nilPath)
+			errorList := ValidateControlPlaneConfig(controlPlane, "1.26.4", nilPath)
 
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup
/platform vsphere

**What this PR does / why we need it**:
Drop support for kubernetes < 1.24 for Vsphere extension provider

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8405

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`provider-vsphere` no longer supports Shoots or Seeds with Кubernetes version < 1.24.
```
