### PR TITLE
Change the default StorageClass name from `default-class` to `default`

### DIFF
--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "storageclassversion" . }}
 kind: StorageClass
 metadata:
-  name: default-class
+  name: default
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
     resources.gardener.cloud/delete-on-invalid-update: "true"

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -92,7 +92,7 @@ string
 </em>
 </td>
 <td>
-<p>DefaultClassStoragePolicyName is the name of the vSphere storage policy to use for the &lsquo;default-class&rsquo; storage class</p>
+<p>DefaultClassStoragePolicyName is the name of the vSphere storage policy to use for the &lsquo;default&rsquo; StorageClass.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/vsphere/types_cloudprofile.go
+++ b/pkg/apis/vsphere/types_cloudprofile.go
@@ -30,7 +30,7 @@ type CloudProfileConfig struct {
 	Folder string
 	// Regions is the specification of regions and zones topology
 	Regions []RegionSpec
-	// DefaultClassStoragePolicyName is the name of the vSphere storage policy to use for the 'default-class' storage class
+	// DefaultClassStoragePolicyName is the name of the vSphere storage policy to use for the 'default' StorageClass.
 	DefaultClassStoragePolicyName string
 	// FailureDomainLabels are the tag categories used for regions and zones.
 	FailureDomainLabels *FailureDomainLabels

--- a/pkg/apis/vsphere/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/vsphere/v1alpha1/types_cloudprofile.go
@@ -31,7 +31,7 @@ type CloudProfileConfig struct {
 	Folder string `json:"folder"`
 	// Regions is the specification of regions and zones topology
 	Regions []RegionSpec `json:"regions"`
-	// DefaultClassStoragePolicyName is the name of the vSphere storage policy to use for the 'default-class' storage class
+	// DefaultClassStoragePolicyName is the name of the vSphere storage policy to use for the 'default' StorageClass.
 	DefaultClassStoragePolicyName string `json:"defaultClassStoragePolicyName"`
 	// FailureDomainLabels are the tag categories used for regions and zones.
 	// +optional


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/platform vsphere

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener/pull/8565. See the PR description of https://github.com/gardener/gardener/pull/8565 for the motivation of this change.



The StorageClass is mainly used during PVC provisioning. I also tested and verified that a PVC with a deleted StorageClass can be successfully attached/detached, mounted/unmounted and deleted.
However, the PVC resize operation requires the StorageClass to be existing. Trying to send an update request that increases the size of the PVC fails with:
```
error: persistentvolumeclaims "claim" could not be patched: persistentvolumeclaims "claim" is forbidden: only dynamically provisioned pvc can be resized and the storageclass that provisions the pvc must support resize
```

However, I think that this should be acceptable because:
- provider-vsphere is not yet productively used
- if needed, the issue can be mitigated by copying the StorageClass with name `default` and created one with name `default-class`

---

Currently the default StorageClass of all provider extensions is named `default`:
- provider-local: https://github.com/gardener/gardener/blob/a47845c1923515fd718fa9386988208227bf83bb/pkg/provider-local/charts/shoot-storageclasses/templates/storageclasses.yaml#L4
- provider-alicloud: https://github.com/gardener/gardener-extension-provider-alicloud/blob/c3958fdf369782fc47eb7fb4d29ab161870c7c2f/charts/internal/shoot-storageclasses/templates/storageclasses.yaml#L5
- provider-aws: https://github.com/gardener/gardener-extension-provider-aws/blob/926f5f8275a5f4c9ef7cab2f2c313f5f120e9957/charts/internal/shoot-storageclasses/templates/storageclasses.yaml#L5
- provider-azure: https://github.com/gardener/gardener-extension-provider-azure/blob/86757db17121163efdd997d392036f1ddcef2e4b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml#L5
- provider-gcp: https://github.com/gardener/gardener-extension-provider-gcp/blob/3713a0c61b59e1baa344c034b45435e2c83bd868/charts/internal/shoot-storageclasses/templates/storageclasses.yaml#L5
- provider-openstack: https://github.com/gardener/gardener-extension-provider-openstack/blob/a5f49663d1d6fb5d9a4e2e9e1b651edb2e346005/pkg/controller/controlplane/valuesprovider.go#L483-L487

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/gardener-extension-registry-cache/issues/3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The default StorageClass is renamed from `default-class` to `default`. PVC referring to the `default-class` should continue to successfully attach/detach,  mount/unmount and delete. However, only the resize operation will be affected. If resize is needed for such PVC, then a StorageClass with name `default-class` (copy of the `default` StorageClass) can be temporary created.
```
